### PR TITLE
layers: Make PIPELINE_STATE data private

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -1041,7 +1041,7 @@ void CMD_BUFFER_STATE::UpdateDrawState(CMD_TYPE cmd_type, const VkPipelineBindPo
             }
         }
     }
-    if (pipe && !pipe->vertex_binding_descriptions_.empty()) {
+    if (pipe && pipe->vertex_input_state && !pipe->vertex_input_state->binding_descriptions.empty()) {
         vertex_buffer_used = true;
     }
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -382,10 +382,10 @@ bool CoreChecks::ValidateStatus(const CMD_BUFFER_STATE *pNode, CBStatusFlags sta
 
 // Return true if for a given PSO, the given state enum is dynamic, else return false
 bool CoreChecks::IsDynamic(const PIPELINE_STATE *pPipeline, const VkDynamicState state) const {
-    if (pPipeline && (pPipeline->GetPipelineType() == VK_PIPELINE_BIND_POINT_GRAPHICS) &&
-        pPipeline->create_info.graphics.pDynamicState) {
-        for (uint32_t i = 0; i < pPipeline->create_info.graphics.pDynamicState->dynamicStateCount; i++) {
-            if (state == pPipeline->create_info.graphics.pDynamicState->pDynamicStates[i]) return true;
+    const auto *dynamic_state = pPipeline->DynamicState();
+    if (pPipeline && (pPipeline->GetPipelineType() == VK_PIPELINE_BIND_POINT_GRAPHICS) && dynamic_state) {
+        for (uint32_t i = 0; i < dynamic_state->dynamicStateCount; i++) {
+            if (state == dynamic_state->pDynamicStates[i]) return true;
         }
     }
     return false;
@@ -400,12 +400,12 @@ bool CoreChecks::ValidateDrawStateFlags(const CMD_BUFFER_STATE *pCB, const PIPEL
         result |=
             ValidateStatus(pCB, CBSTATUS_LINE_WIDTH_SET, "Dynamic line width state not set for this command buffer", msg_code);
     }
-    const auto &create_info = pPipe->create_info.graphics;
+    const auto &create_info = pPipe->GetUnifiedCreateInfo().graphics;
     if (create_info.pRasterizationState && (create_info.pRasterizationState->depthBiasEnable == VK_TRUE)) {
         result |=
             ValidateStatus(pCB, CBSTATUS_DEPTH_BIAS_SET, "Dynamic depth bias state not set for this command buffer", msg_code);
     }
-    if (pPipe->blend_constants_enabled) {
+    if (pPipe->BlendConstantsEnabled()) {
         result |= ValidateStatus(pCB, CBSTATUS_BLEND_CONSTANTS_SET, "Dynamic blend constants state not set for this command buffer",
                                  msg_code);
     }
@@ -632,9 +632,9 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
 
 // For given pipeline, return number of MSAA samples, or one if MSAA disabled
 static VkSampleCountFlagBits GetNumSamples(PIPELINE_STATE const *pipe) {
-    if (pipe->create_info.graphics.pMultisampleState != NULL &&
-        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO == pipe->create_info.graphics.pMultisampleState->sType) {
-        return pipe->create_info.graphics.pMultisampleState->rasterizationSamples;
+    const auto ms_state = pipe->MultisampleState();
+    if (ms_state) {
+        return ms_state->rasterizationSamples;
     }
     return VK_SAMPLE_COUNT_1_BIT;
 }
@@ -675,28 +675,30 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     const char *caller = CommandTypeString(cmd_type);
 
     if (pCB->activeRenderPass && pCB->activeRenderPass->use_dynamic_rendering) {
-        if (pPipeline->rp_state->renderPass() != VK_NULL_HANDLE) {
+        const auto &rp_state = pPipeline->RenderPassState();
+        if (rp_state->renderPass() != VK_NULL_HANDLE) {
             skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_06198,
                 "%s: Currently bound pipeline %s must have been created with a VkGraphicsPipelineCreateInfo::renderPass equal to VK_NULL_HANDLE",
                 caller, report_data->FormatHandle(state.pipeline_state->pipeline()).c_str());
         }
 
-        if (pPipeline->rp_state->dynamic_rendering_pipeline_create_info.viewMask !=
+        if (rp_state->dynamic_rendering_pipeline_create_info.viewMask !=
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask) {
-                skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_view_mask,
-                    "%s: Currently bound pipeline %s viewMask ([%" PRIu32 ") must be equal to pBeginRendering->viewMask ([%" PRIu32 ")",
-                    caller, report_data->FormatHandle(state.pipeline_state->pipeline()).c_str(),
-                    pPipeline->rp_state->dynamic_rendering_pipeline_create_info.viewMask,
-                    pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask);
+            skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_view_mask,
+                             "%s: Currently bound pipeline %s viewMask ([%" PRIu32
+                             ") must be equal to pBeginRendering->viewMask ([%" PRIu32 ")",
+                             caller, report_data->FormatHandle(state.pipeline_state->pipeline()).c_str(),
+                             rp_state->dynamic_rendering_pipeline_create_info.viewMask,
+                             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask);
         }
 
-        if (pPipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount !=
+        if (rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount !=
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount) {
             skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_color_count,
                              "%s: Currently bound pipeline %s colorAttachmentCount ([%" PRIu32
                              ") must be equal to pBeginRendering->colorAttachmentCount ([%" PRIu32 ")",
                              caller, report_data->FormatHandle(state.pipeline_state->pipeline()).c_str(),
-                             pPipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount,
+                             rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount,
                              pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount);
         }
 
@@ -705,11 +707,14 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 if (pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pColorAttachments[i].imageView != VK_NULL_HANDLE) {
                     auto view_state = Get<IMAGE_VIEW_STATE>(
                         pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pColorAttachments[i].imageView);
-                    if (view_state->create_info.format != pPipeline->rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[i]) {
-                        skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_color_formats,
-                            "%s: Color attachment ([%" PRIu32 ") imageView format (%s) must match corresponding format in pipeline (%s)",
-                            caller, i, string_VkFormat(view_state->create_info.format),
-                                       string_VkFormat(pPipeline->rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[i]));
+                    if (view_state->create_info.format !=
+                        rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[i]) {
+                        skip |=
+                            LogError(pCB->commandBuffer(), vuid.dynamic_rendering_color_formats,
+                                     "%s: Color attachment ([%" PRIu32
+                                     ") imageView format (%s) must match corresponding format in pipeline (%s)",
+                                     caller, i, string_VkFormat(view_state->create_info.format),
+                                     string_VkFormat(rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[i]));
                     }
                 }
             }
@@ -719,13 +724,11 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
             auto view_state =
                 Get<IMAGE_VIEW_STATE>(pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pDepthAttachment->imageView);
-            if (view_state->create_info.format !=
-                pPipeline->rp_state->dynamic_rendering_pipeline_create_info.depthAttachmentFormat) {
-                skip |= LogError(
-                    pCB->commandBuffer(), vuid.dynamic_rendering_depth_format,
-                    "%s: Depth attachment imageView format (%s) must match corresponding format in pipeline (%s)",
-                    caller, string_VkFormat(view_state->create_info.format),
-                    string_VkFormat(pPipeline->rp_state->dynamic_rendering_pipeline_create_info.depthAttachmentFormat));
+            if (view_state->create_info.format != rp_state->dynamic_rendering_pipeline_create_info.depthAttachmentFormat) {
+                skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_depth_format,
+                                 "%s: Depth attachment imageView format (%s) must match corresponding format in pipeline (%s)",
+                                 caller, string_VkFormat(view_state->create_info.format),
+                                 string_VkFormat(rp_state->dynamic_rendering_pipeline_create_info.depthAttachmentFormat));
             }
         }
 
@@ -733,13 +736,11 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
             auto view_state =
                 Get<IMAGE_VIEW_STATE>(pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pStencilAttachment->imageView);
-            if (view_state->create_info.format !=
-                pPipeline->rp_state->dynamic_rendering_pipeline_create_info.stencilAttachmentFormat) {
-                skip |= LogError(
-                    pCB->commandBuffer(), vuid.dynamic_rendering_stencil_format,
-                    "%s: Stencil attachment imageView format (%s) must match corresponding format in pipeline (%s)", caller,
-                    string_VkFormat(view_state->create_info.format),
-                    string_VkFormat(pPipeline->rp_state->dynamic_rendering_pipeline_create_info.stencilAttachmentFormat));
+            if (view_state->create_info.format != rp_state->dynamic_rendering_pipeline_create_info.stencilAttachmentFormat) {
+                skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_stencil_format,
+                                 "%s: Stencil attachment imageView format (%s) must match corresponding format in pipeline (%s)",
+                                 caller, string_VkFormat(view_state->create_info.format),
+                                 string_VkFormat(rp_state->dynamic_rendering_pipeline_create_info.stencilAttachmentFormat));
             }
         }
 
@@ -747,8 +748,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pNext);
         if (rendering_fragment_shading_rate_attachment_info &&
             (rendering_fragment_shading_rate_attachment_info->imageView != VK_NULL_HANDLE)) {
-            if (!(pPipeline->create_info.graphics.flags &
-                  VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
+            if (!(rp_state->createInfo.flags & VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
                 skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_fsr,
                                  "%s: Currently bound graphics pipeline %s must have been created with "
                                  "VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
@@ -760,8 +760,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
             pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.pNext);
         if (rendering_fragment_shading_rate_density_map &&
             (rendering_fragment_shading_rate_density_map->imageView != VK_NULL_HANDLE)) {
-            if (!(pPipeline->create_info.graphics.flags &
-                  VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT)) {
+            if (!(rp_state->createInfo.flags & VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT)) {
                 skip |= LogError(pCB->commandBuffer(), vuid.dynamic_rendering_fdm,
                                  "%s: Currently bound graphics pipeline %s must have been created with "
                                  "VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT",
@@ -770,8 +769,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         }
 
         // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV
-        auto p_attachment_sample_count_info =
-            LvlFindInChain<VkAttachmentSampleCountInfoAMD>(pPipeline->create_info.graphics.pNext);
+        const auto &graphics_create_info = pPipeline->GetUnifiedCreateInfo().graphics;
+        auto p_attachment_sample_count_info = LvlFindInChain<VkAttachmentSampleCountInfoAMD>(graphics_create_info.pNext);
 
         if (p_attachment_sample_count_info) {
             if (pCB->activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount > 0) {
@@ -890,8 +889,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 break;
             }
         }
-        if (primitives_generated_query && pPipeline->create_info.graphics.pRasterizationState &&
-            pPipeline->create_info.graphics.pRasterizationState->rasterizerDiscardEnable == VK_TRUE) {
+        const auto rp_state = pPipeline->RasterizationState();
+        if (primitives_generated_query && rp_state && rp_state->rasterizerDiscardEnable == VK_TRUE) {
             skip |= LogError(pCB->commandBuffer(), vuid.primitives_generated,
                              "%s: a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
                              "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable set to VK_TRUE, but  "
@@ -927,9 +926,9 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     }
 
     // Verify vertex binding
-    if (pPipeline->vertex_binding_descriptions_.size() > 0) {
-        for (size_t i = 0; i < pPipeline->vertex_binding_descriptions_.size(); i++) {
-            const auto vertex_binding = pPipeline->vertex_binding_descriptions_[i].binding;
+    if (pPipeline->vertex_input_state && pPipeline->vertex_input_state->binding_descriptions.size() > 0) {
+        for (size_t i = 0; i < pPipeline->vertex_input_state->binding_descriptions.size(); i++) {
+            const auto vertex_binding = pPipeline->vertex_input_state->binding_descriptions[i].binding;
             if (current_vtx_bfr_binding_info.size() < (vertex_binding + 1)) {
                 skip |= LogError(pCB->commandBuffer(), vuid.vertex_binding,
                                  "%s: %s expects that this Command Buffer's vertex binding Index %u should be set via "
@@ -950,17 +949,18 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         }
 
         // Verify vertex attribute address alignment
-        for (size_t i = 0; i < pPipeline->vertex_attribute_descriptions_.size(); i++) {
-            const auto &attribute_description = pPipeline->vertex_attribute_descriptions_[i];
-            const uint32_t vertex_binding = attribute_description.binding;
-            const uint32_t attribute_offset = attribute_description.offset;
+        for (size_t i = 0; i < pPipeline->vertex_input_state->vertex_attribute_descriptions.size(); i++) {
+            const auto &attribute_description = pPipeline->vertex_input_state->vertex_attribute_descriptions[i];
+            const auto vertex_binding = attribute_description.binding;
+            const auto attribute_offset = attribute_description.offset;
 
-            const auto &vertex_binding_map_it = pPipeline->vertex_binding_to_index_map_.find(vertex_binding);
-            if ((vertex_binding_map_it != pPipeline->vertex_binding_to_index_map_.cend()) &&
+            const auto &vertex_binding_map_it = pPipeline->vertex_input_state->binding_to_index_map.find(vertex_binding);
+            if ((vertex_binding_map_it != pPipeline->vertex_input_state->binding_to_index_map.cend()) &&
                 (vertex_binding < current_vtx_bfr_binding_info.size()) &&
                 ((current_vtx_bfr_binding_info[vertex_binding].buffer_state) ||
                  enabled_features.robustness2_features.nullDescriptor)) {
-                uint32_t vertex_buffer_stride = pPipeline->vertex_binding_descriptions_[vertex_binding_map_it->second].stride;
+                auto vertex_buffer_stride =
+                    pPipeline->vertex_input_state->binding_descriptions[vertex_binding_map_it->second].stride;
                 if (IsDynamic(pPipeline, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT)) {
                     vertex_buffer_stride = static_cast<uint32_t>(current_vtx_bfr_binding_info[vertex_binding].stride);
                     uint32_t attribute_binding_extent =
@@ -978,7 +978,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 // Use 1 as vertex/instance index to use buffer stride as well
                 const VkDeviceSize attrib_address = vertex_buffer_offset + vertex_buffer_stride + attribute_offset;
 
-                const VkDeviceSize vtx_attrib_req_alignment = pPipeline->vertex_attribute_alignments_[i];
+                const VkDeviceSize vtx_attrib_req_alignment = pPipeline->vertex_input_state->vertex_attribute_alignments[i];
 
                 if (SafeModulo(attrib_address, vtx_attrib_req_alignment) != 0) {
                     LogObjectList objlist(current_vtx_bfr_binding_info[vertex_binding].buffer_state->buffer());
@@ -1007,9 +1007,10 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     // If Viewport or scissors are dynamic, verify that dynamic count matches PSO count.
     // Skip check if rasterization is disabled, if there is no viewport, or if viewport/scissors are being inherited.
     bool dyn_viewport = IsDynamic(pPipeline, VK_DYNAMIC_STATE_VIEWPORT);
-    const auto &create_info = pPipeline->create_info.graphics;
-    if ((!create_info.pRasterizationState || (create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE)) &&
-        create_info.pViewportState && pCB->inheritedViewportDepths.size() == 0) {
+    const auto *raster_state = pPipeline->RasterizationState();
+    const auto *viewport_state = pPipeline->ViewportState();
+    if ((!raster_state || (raster_state->rasterizerDiscardEnable == VK_FALSE)) && viewport_state &&
+        (pCB->inheritedViewportDepths.size() == 0)) {
         bool dyn_scissor = IsDynamic(pPipeline, VK_DYNAMIC_STATE_SCISSOR);
 
         // NB (akeley98): Current validation layers do not detect the error where vkCmdSetViewport (or scissor) was called, but
@@ -1017,7 +1018,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         // This condition be detected by checking trashedViewportMask & viewportMask (trashedScissorMask & scissorMask) is
         // nonzero in the range of bits needed by the pipeline.
         if (dyn_viewport) {
-            const auto required_viewports_mask = (1 << create_info.pViewportState->viewportCount) - 1;
+            const auto required_viewports_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_viewport_mask = ~pCB->viewportMask & required_viewports_mask;
             if (missing_viewport_mask) {
                 std::stringstream ss;
@@ -1029,7 +1030,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         }
 
         if (dyn_scissor) {
-            const auto required_scissor_mask = (1 << create_info.pViewportState->scissorCount) - 1;
+            const auto required_scissor_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_scissor_mask = ~pCB->scissorMask & required_scissor_mask;
             if (missing_scissor_mask) {
                 std::stringstream ss;
@@ -1045,7 +1046,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
 
         // VUID {refpage}-viewportCount-03417
         if (dyn_viewport_count && !dyn_scissor_count) {
-            const auto required_viewport_mask = (1 << create_info.pViewportState->scissorCount) - 1;
+            const auto required_viewport_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_viewport_mask = ~pCB->viewportWithCountMask & required_viewport_mask;
             if (missing_viewport_mask) {
                 std::stringstream ss;
@@ -1058,7 +1059,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
 
         // VUID {refpage}-scissorCount-03418
         if (dyn_scissor_count && !dyn_viewport_count) {
-            const auto required_scissor_mask = (1 << create_info.pViewportState->viewportCount) - 1;
+            const auto required_scissor_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_scissor_mask = ~pCB->scissorWithCountMask & required_scissor_mask;
             if (missing_scissor_mask) {
                 std::stringstream ss;
@@ -1084,7 +1085,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
 
     // If inheriting viewports, verify that not using more than inherited.
     if (pCB->inheritedViewportDepths.size() != 0 && dyn_viewport) {
-        uint32_t viewport_count = create_info.pViewportState->viewportCount;
+        uint32_t viewport_count = viewport_state->viewportCount;
         uint32_t max_inherited  = uint32_t(pCB->inheritedViewportDepths.size());
         if (viewport_count > max_inherited) {
             skip |= LogError(device, vuid.dynamic_state,
@@ -1096,7 +1097,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     // Verify that any MSAA request in PSO matches sample# in bound FB
     // Verify that blend is enabled only if supported by subpasses image views format features
     // Skip the check if rasterization is disabled.
-    if (!create_info.pRasterizationState || (create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE)) {
+    if (!raster_state || (raster_state->rasterizerDiscardEnable == VK_FALSE)) {
         VkSampleCountFlagBits pso_num_samples = GetNumSamples(pPipeline);
         if (pCB->activeRenderPass) {
             if (pCB->activeRenderPass->use_dynamic_rendering || pCB->activeRenderPass->use_dynamic_rendering_inherited) {
@@ -1114,10 +1115,10 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                         subpass_num_samples |= static_cast<unsigned>(render_pass_info->pAttachments[attachment].samples);
 
                         const auto *imageview_state = pCB->GetActiveAttachmentImageViewState(attachment);
-                        if (imageview_state != nullptr && pPipeline->create_info.graphics.pColorBlendState &&
-                            attachment < pPipeline->create_info.graphics.pColorBlendState->attachmentCount) {
+                        const auto *color_blend_state = pPipeline->ColorBlendState();
+                        if (imageview_state && color_blend_state && (attachment < color_blend_state->attachmentCount)) {
                             if ((imageview_state->format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR) == 0 &&
-                                pPipeline->create_info.graphics.pColorBlendState->pAttachments[i].blendEnable != VK_FALSE) {
+                                color_blend_state->pAttachments[i].blendEnable != VK_FALSE) {
                                 skip |=
                                     LogError(pPipeline->pipeline(), vuid.blend_enable,
                                              "%s: Image view's format features of the color attachment (%" PRIu32
@@ -1156,19 +1157,20 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     }
     // Verify that PSO creation renderPass is compatible with active renderPass
     if (pCB->activeRenderPass && !pCB->activeRenderPass->use_dynamic_rendering) {
+        const auto &rp_state = pPipeline->RenderPassState();
         // TODO: AMD extension codes are included here, but actual function entrypoints are not yet intercepted
-        if (pCB->activeRenderPass->renderPass() != pPipeline->rp_state->renderPass()) {
+        if (pCB->activeRenderPass->renderPass() != rp_state->renderPass()) {
             // renderPass that PSO was created with must be compatible with active renderPass that PSO is being used with
             skip |= ValidateRenderPassCompatibility("active render pass", pCB->activeRenderPass.get(), "pipeline state object",
-                                                    pPipeline->rp_state.get(), caller, vuid.render_pass_compatible);
+                                                    rp_state.get(), caller, vuid.render_pass_compatible);
         }
-        if (pPipeline->create_info.graphics.subpass != pCB->activeSubpass) {
-            skip |=
-                LogError(pPipeline->pipeline(), vuid.subpass_index, "%s: Pipeline was built for subpass %u but used in subpass %u.",
-                         caller, pPipeline->create_info.graphics.subpass, pCB->activeSubpass);
+        const auto subpass = pPipeline->Subpass();
+        if (subpass != pCB->activeSubpass) {
+            skip |= LogError(pPipeline->pipeline(), vuid.subpass_index,
+                             "%s: Pipeline was built for subpass %u but used in subpass %u.", caller, subpass, pCB->activeSubpass);
         }
         // Check if depth stencil attachment was created with sample location compatible bit
-        if (pPipeline->sample_location_enabled == VK_TRUE) {
+        if (pPipeline->SampleLocationEnabled() == VK_TRUE) {
             const safe_VkAttachmentReference2 *ds_attachment =
                 pCB->activeRenderPass->createInfo.pSubpasses[pCB->activeSubpass].pDepthStencilAttachment;
             const FRAMEBUFFER_STATE *fb_state = pCB->activeFramebuffer.get();
@@ -1210,7 +1212,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                            vuid.color_write_enable);
     if (IsDynamic(pPipeline, VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT) && pCB->status & CBSTATUS_COLOR_WRITE_ENABLE_SET) {
         uint32_t blend_attachment_count =
-            pCB->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)->create_info.graphics.pColorBlendState->attachmentCount;
+            pCB->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)->ColorBlendState()->attachmentCount;
         if (pCB->dynamicColorWriteEnableAttachmentCount != blend_attachment_count) {
             skip |= LogError(
                 pCB->commandBuffer(), vuid.color_write_enable,
@@ -1228,7 +1230,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                            vuid.primitive_topology);
     if (IsDynamic(pPipeline, VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT)) {
         bool compatible_topology = false;
-        switch (create_info.pInputAssemblyState->topology) {
+        const auto input_assembly_state = pPipeline->InputAssemblyState();
+        switch (input_assembly_state->topology) {
             case VK_PRIMITIVE_TOPOLOGY_POINT_LIST:
                 switch (pCB->primitiveTopology) {
                     case VK_PRIMITIVE_TOPOLOGY_POINT_LIST:
@@ -1287,7 +1290,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                              "%s: the last primitive topology %s state set by vkCmdSetPrimitiveTopologyEXT is "
                              "not compatible with the pipeline topology %s.",
                              caller, string_VkPrimitiveTopology(pCB->primitiveTopology),
-                             string_VkPrimitiveTopology(pPipeline->create_info.graphics.pInputAssemblyState->topology));
+                             string_VkPrimitiveTopology(input_assembly_state->topology));
         }
     }
 
@@ -1366,7 +1369,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     }
     // Now complete other state checks
     string error_string;
-    const auto *pipeline_layout = pipe->pipeline_layout.get();
+    auto const &pipeline_layout = pipe->PipelineLayoutState();
 
     // Check if the current pipeline is compatible for the maximum used set with the bound sets.
     if (pipe->active_slots.size() > 0 && !CompatForSet(pipe->max_active_slot, state, pipeline_layout->compat_for_set)) {
@@ -1388,8 +1391,8 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
             result |= LogError(cb_node->commandBuffer(), kVUID_Core_DrawState_DescriptorSetNotBound,
                                "%s(): %s uses set #%u but that set is not bound.", CommandTypeString(cmd_type),
                                report_data->FormatHandle(pipe->pipeline()).c_str(), set_index);
-        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[set_index].bound_descriptor_set.get(), pipeline_layout,
-                                                 set_index, error_string)) {
+        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[set_index].bound_descriptor_set.get(),
+                                                 pipeline_layout.get(), set_index, error_string)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
             VkDescriptorSet set_handle = state.per_set[set_index].bound_descriptor_set->GetSet();
             LogObjectList objlist(set_handle);
@@ -1515,39 +1518,43 @@ bool CoreChecks::ValidateCmdRayQueryState(const CMD_BUFFER_STATE *cb_state, CMD_
 
 bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE *pPipeline) const {
     bool skip = false;
-    const auto& create_info = pPipeline->create_info.graphics;
-    if (create_info.pColorBlendState) {
-        const auto *subpass_desc = &pPipeline->rp_state->createInfo.pSubpasses[create_info.subpass];
+    const auto *color_blend_state = pPipeline->ColorBlendState();
+    const auto &rp_state = pPipeline->RenderPassState();
+    if (rp_state && color_blend_state) {
+        const auto subpass = pPipeline->Subpass();
+        const auto *subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
 
-        uint32_t numberColorAttachments = (pPipeline->rp_state->use_dynamic_rendering)
-                                              ? pPipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount
+        uint32_t numberColorAttachments = (rp_state->use_dynamic_rendering)
+                                              ? rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount
                                               : subpass_desc->colorAttachmentCount;
 
-        for (uint32_t i = 0; i < pPipeline->attachments.size() && i < numberColorAttachments; ++i) {
+        for (uint32_t i = 0; i < pPipeline->Attachments().size() && i < numberColorAttachments; ++i) {
             VkFormatFeatureFlags2KHR format_features;
 
-            if (pPipeline->rp_state->use_dynamic_rendering) {
-                if (create_info.pColorBlendState->attachmentCount != numberColorAttachments) {
+            if (rp_state->use_dynamic_rendering) {
+                if (color_blend_state->attachmentCount != numberColorAttachments) {
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06055",
-                        "Pipeline %s: VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32 ") must equal pColorBlendState->attachmentCount (%" PRIu32 ")",
-                        report_data->FormatHandle(pPipeline->pipeline()).c_str(), numberColorAttachments, create_info.pColorBlendState->attachmentCount);
+                                     "Pipeline %s: VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32
+                                     ") must equal pColorBlendState->attachmentCount (%" PRIu32 ")",
+                                     report_data->FormatHandle(pPipeline->pipeline()).c_str(), numberColorAttachments,
+                                     color_blend_state->attachmentCount);
                 }
             } else {
                 const auto attachment = subpass_desc->pColorAttachments[i].attachment;
                 if (attachment == VK_ATTACHMENT_UNUSED) continue;
 
-                const auto attachment_desc = pPipeline->rp_state->createInfo.pAttachments[attachment];
+                const auto attachment_desc = rp_state->createInfo.pAttachments[attachment];
                 format_features = GetPotentialFormatFeatures(attachment_desc.format);
 
-                if (create_info.pRasterizationState && !create_info.pRasterizationState->rasterizerDiscardEnable &&
-                    pPipeline->attachments[i].blendEnable &&
+                const auto *raster_state = pPipeline->RasterizationState();
+                if (raster_state && !raster_state->rasterizerDiscardEnable && pPipeline->Attachments()[i].blendEnable &&
                     !(format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR)) {
                     skip |= LogError(
                         device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06041",
                         "vkCreateGraphicsPipelines(): pipeline.pColorBlendState.pAttachments[%" PRIu32
                         "].blendEnable is VK_TRUE but format %s of the corresponding attachment description (subpass %" PRIu32
                         ", attachment %" PRIu32 ") does not support VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT.",
-                        i, string_VkFormat(attachment_desc.format), create_info.subpass, attachment);
+                        i, string_VkFormat(attachment_desc.format), subpass, attachment);
                 }
             }
         }
@@ -1560,32 +1567,33 @@ bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STA
     bool skip = false;
 
     const auto *pipeline = pPipelines[pipelineIndex].get();
-    const auto &create_info = pipeline->create_info.graphics;
     // If create derivative bit is set, check that we've specified a base
     // pipeline correctly, and that the base pipeline was created to allow
     // derivatives.
-    if (create_info.flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
+    if (pipeline->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
         std::shared_ptr<const PIPELINE_STATE> base_pipeline;
-        if (!((create_info.basePipelineHandle != VK_NULL_HANDLE) ^ (create_info.basePipelineIndex != -1))) {
+        const auto base_handle = pipeline->BasePipeline();
+        const auto base_index = pipeline->BasePipelineIndex();
+        if (!((base_handle != VK_NULL_HANDLE) ^ (base_index != -1))) {
             // TODO: This check is a superset of VUID-VkGraphicsPipelineCreateInfo-flags-00724 and
             // TODO: VUID-VkGraphicsPipelineCreateInfo-flags-00725
             skip |= LogError(device, kVUID_Core_DrawState_InvalidPipelineCreateState,
                              "Invalid Pipeline CreateInfo[%d]: exactly one of base pipeline index and handle must be specified",
                              pipelineIndex);
-        } else if (create_info.basePipelineIndex != -1) {
-            if (create_info.basePipelineIndex >= pipelineIndex) {
+        } else if (base_index != -1) {
+            if (base_index >= pipelineIndex) {
                 skip |=
                     LogError(device, "VUID-vkCreateGraphicsPipelines-flags-00720",
                              "Invalid Pipeline CreateInfo[%d]: base pipeline must occur earlier in array than derivative pipeline.",
                              pipelineIndex);
             } else {
-                base_pipeline = pPipelines[create_info.basePipelineIndex];
+                base_pipeline = pPipelines[base_index];
             }
-        } else if (create_info.basePipelineHandle != VK_NULL_HANDLE) {
-            base_pipeline = Get<PIPELINE_STATE>(create_info.basePipelineHandle);
+        } else if (base_handle != VK_NULL_HANDLE) {
+            base_pipeline = Get<PIPELINE_STATE>(base_handle);
         }
 
-        if (base_pipeline && !(base_pipeline->create_info.graphics.flags & VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)) {
+        if (base_pipeline && !(base_pipeline->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)) {
             skip |= LogError(device, "VUID-vkCreateGraphicsPipelines-flags-00721",
                              "Invalid Pipeline CreateInfo[%d]: base pipeline does not allow derivatives.", pipelineIndex);
         }
@@ -1602,7 +1610,7 @@ bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STA
         }
 
         // Validate vertex inputs
-        for (const auto &desc : pipeline->vertex_binding_descriptions_) {
+        for (const auto &desc : pipeline->vertex_input_state->binding_descriptions) {
             const auto min_alignment = phys_dev_ext_props.portability_props.minVertexInputBindingStrideAlignment;
             if ((desc.stride < min_alignment) || (min_alignment == 0) || ((desc.stride % min_alignment) != 0)) {
                 skip |= LogError(
@@ -1615,10 +1623,10 @@ bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STA
 
         // Validate vertex attributes
         if (VK_FALSE == enabled_features.portability_subset_features.vertexAttributeAccessBeyondStride) {
-            for (const auto &attrib : pipeline->vertex_attribute_descriptions_) {
-                const auto vertex_binding_map_it = pipeline->vertex_binding_to_index_map_.find(attrib.binding);
-                if (vertex_binding_map_it != pipeline->vertex_binding_to_index_map_.cend()) {
-                    const auto& desc = pipeline->vertex_binding_descriptions_[vertex_binding_map_it->second];
+            for (const auto &attrib : pipeline->vertex_input_state->vertex_attribute_descriptions) {
+                const auto vertex_binding_map_it = pipeline->vertex_input_state->binding_to_index_map.find(attrib.binding);
+                if (vertex_binding_map_it != pipeline->vertex_input_state->binding_to_index_map.cend()) {
+                    const auto &desc = pipeline->vertex_input_state->binding_descriptions[vertex_binding_map_it->second];
                     if ((attrib.offset + FormatElementSize(attrib.format)) > desc.stride) {
                         skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457",
                                          "Invalid Pipeline CreateInfo[%d] (portability error): (attribute.offset + "
@@ -1630,7 +1638,7 @@ bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STA
         }
 
         // Validate polygon mode
-        auto raster_state_ci = create_info.pRasterizationState;
+        auto raster_state_ci = pipeline->RasterizationState();
         if ((VK_FALSE == enabled_features.portability_subset_features.pointPolygons) && raster_state_ci &&
             (VK_FALSE == raster_state_ci->rasterizerDiscardEnable) && (VK_POLYGON_MODE_POINT == raster_state_ci->polygonMode)) {
             skip |=
@@ -1645,30 +1653,31 @@ bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STA
 // UNLOCKED pipeline validation. DO NOT lookup objects in the CoreChecks->* maps in this function.
 bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint32_t pipelineIndex) const {
     bool skip = false;
-    const auto &create_info = pPipeline->create_info.graphics;
-
     safe_VkSubpassDescription2 *subpass_desc = nullptr;
 
-    if (!pPipeline->rp_state->use_dynamic_rendering) {
+    const auto &rp_state = pPipeline->RenderPassState();
+    const auto subpass = pPipeline->Subpass();
+    if (rp_state && !rp_state->use_dynamic_rendering) {
         // Ensure the subpass index is valid. If not, then ValidateGraphicsPipelineShaderState
         // produces nonsense errors that confuse users. Other layers should already
         // emit errors for renderpass being invalid.
-        subpass_desc = &pPipeline->rp_state->createInfo.pSubpasses[create_info.subpass];
-        if (create_info.subpass >= pPipeline->rp_state->createInfo.subpassCount) {
+        subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
+        if (subpass >= rp_state->createInfo.subpassCount) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06046",
                              "vkCreateGraphicsPipelines() Invalid Pipeline CreateInfo[%" PRIu32
                              "] State: Subpass index %u is out of range for this renderpass (0..%u).",
-                             pipelineIndex, create_info.subpass, pPipeline->rp_state->createInfo.subpassCount - 1);
+                             pipelineIndex, subpass, rp_state->createInfo.subpassCount - 1);
             subpass_desc = nullptr;
         }
     }
 
-    if (create_info.pDepthStencilState != NULL) {
-        if ((((create_info.pDepthStencilState->flags &
-               VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_ARM) != 0) ||
-             ((create_info.pDepthStencilState->flags &
-               VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM) != 0)) &&
-            (create_info.renderPass == VK_NULL_HANDLE)) {
+    const auto ds_state = pPipeline->DepthStencilState();
+    if (ds_state) {
+        if ((((ds_state->flags & VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_ARM) !=
+              0) ||
+             ((ds_state->flags & VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM) !=
+              0)) &&
+            rp_state) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-06483",
                              "vkCreateGraphicsPipelines(): pPipelines[%" PRIu32
                              "].pDepthStencilState[%s] contains "
@@ -1676,17 +1685,15 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              " VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM, "
                              "renderpass must"
                              "not be VK_NULL_HANDLE.",
-                             pipelineIndex,
-                             string_VkPipelineDepthStencilStateCreateFlags(create_info.pDepthStencilState->flags).c_str());
+                             pipelineIndex, string_VkPipelineDepthStencilStateCreateFlags(ds_state->flags).c_str());
         }
     }
 
-    if (create_info.pColorBlendState != NULL) {
-        const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state = create_info.pColorBlendState;
-
-        if (((create_info.pColorBlendState->flags &
-              VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM) != 0) &&
-            (create_info.renderPass == VK_NULL_HANDLE)) {
+    const auto color_blend_state = pPipeline->ColorBlendState();
+    if (color_blend_state) {
+        if (((color_blend_state->flags & VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM) !=
+             0) &&
+            rp_state) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-06482",
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                              "]: created with"
@@ -1696,8 +1703,8 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
 
         // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV
-        auto attachment_sample_count_info = LvlFindInChain<VkAttachmentSampleCountInfoAMD>(create_info.pNext);
-        const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(create_info.pNext);
+        auto attachment_sample_count_info = LvlFindInChain<VkAttachmentSampleCountInfoAMD>(pPipeline->PNext());
+        const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pPipeline->PNext());
         if (rendering_struct && attachment_sample_count_info &&
             (attachment_sample_count_info->colorAttachmentCount != rendering_struct->colorAttachmentCount)) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06063",
@@ -1715,13 +1722,14 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                              "]: %s subpass %u has colorAttachmentCount of %u which doesn't "
                              "match the pColorBlendState->attachmentCount of %u.",
-                             pipelineIndex, report_data->FormatHandle(pPipeline->rp_state->renderPass()).c_str(),
-                             create_info.subpass, subpass_desc->colorAttachmentCount, color_blend_state->attachmentCount);
+                             pipelineIndex, report_data->FormatHandle(rp_state->renderPass()).c_str(), subpass,
+                             subpass_desc->colorAttachmentCount, color_blend_state->attachmentCount);
         }
+        const auto &pipe_attachments = pPipeline->Attachments();
         if (!enabled_features.core.independentBlend) {
-            if (pPipeline->attachments.size() > 1) {
-                const VkPipelineColorBlendAttachmentState *const attachments = &pPipeline->attachments[0];
-                for (size_t i = 1; i < pPipeline->attachments.size(); i++) {
+            if (pipe_attachments.size() > 1) {
+                const auto *const attachments = &pipe_attachments[0];
+                for (size_t i = 1; i < pipe_attachments.size(); i++) {
                     // Quoting the spec: "If [the independent blend] feature is not enabled, the VkPipelineColorBlendAttachmentState
                     // settings for all color attachments must be identical." VkPipelineColorBlendAttachmentState contains
                     // only attachment state, so memcmp is best suited for the comparison
@@ -1737,67 +1745,67 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                 }
             }
         }
-        if (!enabled_features.core.logicOp && (create_info.pColorBlendState->logicOpEnable != VK_FALSE)) {
+        if (!enabled_features.core.logicOp && (color_blend_state->logicOpEnable != VK_FALSE)) {
             skip |= LogError(device, "VUID-VkPipelineColorBlendStateCreateInfo-logicOpEnable-00606",
                              "Invalid Pipeline CreateInfo[%" PRIu32
                              "]: If logic operations feature not enabled, logicOpEnable must be VK_FALSE.",
                              pipelineIndex);
         }
-        for (size_t i = 0; i < pPipeline->attachments.size(); i++) {
-            if ((pPipeline->attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
-                (pPipeline->attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
-                (pPipeline->attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
-                (pPipeline->attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
+        for (size_t i = 0; i < pipe_attachments.size(); i++) {
+            if ((pipe_attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
+                (pipe_attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
+                (pipe_attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
+                (pipe_attachments[i].srcColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
                 if (!enabled_features.core.dualSrcBlend) {
                     skip |= LogError(device, "VUID-VkPipelineColorBlendAttachmentState-srcColorBlendFactor-00608",
                                      "vkCreateGraphicsPipelines(): pPipelines[%" PRIu32
                                      "].pColorBlendState.pAttachments[" PRINTF_SIZE_T_SPECIFIER
                                      "].srcColorBlendFactor uses a dual-source blend factor (%d), but this device feature is not "
                                      "enabled.",
-                                     pipelineIndex, i, pPipeline->attachments[i].srcColorBlendFactor);
+                                     pipelineIndex, i, pipe_attachments[i].srcColorBlendFactor);
                 }
             }
-            if ((pPipeline->attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
-                (pPipeline->attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
-                (pPipeline->attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
-                (pPipeline->attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
+            if ((pipe_attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
+                (pipe_attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
+                (pipe_attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
+                (pipe_attachments[i].dstColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
                 if (!enabled_features.core.dualSrcBlend) {
                     skip |= LogError(device, "VUID-VkPipelineColorBlendAttachmentState-dstColorBlendFactor-00609",
                                      "vkCreateGraphicsPipelines(): pPipelines[%" PRIu32
                                      "].pColorBlendState.pAttachments[" PRINTF_SIZE_T_SPECIFIER
                                      "].dstColorBlendFactor uses a dual-source blend factor (%d), but this device feature is not "
                                      "enabled.",
-                                     pipelineIndex, i, pPipeline->attachments[i].dstColorBlendFactor);
+                                     pipelineIndex, i, pipe_attachments[i].dstColorBlendFactor);
                 }
             }
-            if ((pPipeline->attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
-                (pPipeline->attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
-                (pPipeline->attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
-                (pPipeline->attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
+            if ((pipe_attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
+                (pipe_attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
+                (pipe_attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
+                (pipe_attachments[i].srcAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
                 if (!enabled_features.core.dualSrcBlend) {
                     skip |= LogError(device, "VUID-VkPipelineColorBlendAttachmentState-srcAlphaBlendFactor-00610",
                                      "vkCreateGraphicsPipelines(): pPipelines[%" PRIu32
                                      "].pColorBlendState.pAttachments[" PRINTF_SIZE_T_SPECIFIER
                                      "].srcAlphaBlendFactor uses a dual-source blend factor (%d), but this device feature is not "
                                      "enabled.",
-                                     pipelineIndex, i, pPipeline->attachments[i].srcAlphaBlendFactor);
+                                     pipelineIndex, i, pipe_attachments[i].srcAlphaBlendFactor);
                 }
             }
-            if ((pPipeline->attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
-                (pPipeline->attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
-                (pPipeline->attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
-                (pPipeline->attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
+            if ((pipe_attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_COLOR) ||
+                (pipe_attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR) ||
+                (pipe_attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_SRC1_ALPHA) ||
+                (pipe_attachments[i].dstAlphaBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)) {
                 if (!enabled_features.core.dualSrcBlend) {
                     skip |= LogError(device, "VUID-VkPipelineColorBlendAttachmentState-dstAlphaBlendFactor-00611",
                                      "vkCreateGraphicsPipelines(): pPipelines[%" PRIu32
                                      "].pColorBlendState.pAttachments[" PRINTF_SIZE_T_SPECIFIER
                                      "].dstAlphaBlendFactor uses a dual-source blend factor (%d), but this device feature is not "
                                      "enabled.",
-                                     pipelineIndex, i, pPipeline->attachments[i].dstAlphaBlendFactor);
+                                     pipelineIndex, i, pipe_attachments[i].dstAlphaBlendFactor);
                 }
             }
         }
-        auto color_write = lvl_find_in_chain<VkPipelineColorWriteCreateInfoEXT>(create_info.pColorBlendState->pNext);
+        auto color_write = lvl_find_in_chain<VkPipelineColorWriteCreateInfoEXT>(color_blend_state->pNext);
         if (color_write) {
             // if over limit don't give extra redundant error of mismatch of attachmentCount
             if (color_write->attachmentCount > phys_dev_props.limits.maxColorAttachments) {
@@ -1827,8 +1835,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                 }
             }
         }
-        const auto *color_blend_advanced =
-            LvlFindInChain<VkPipelineColorBlendAdvancedStateCreateInfoEXT>(create_info.pColorBlendState->pNext);
+        const auto *color_blend_advanced = LvlFindInChain<VkPipelineColorBlendAdvancedStateCreateInfoEXT>(color_blend_state->pNext);
         if (color_blend_advanced) {
             if (!phys_dev_ext_props.blend_operation_advanced_props.advancedBlendCorrelatedOverlap &&
                 color_blend_advanced->blendOverlap != VK_BLEND_OVERLAP_UNCORRELATED_EXT) {
@@ -1907,8 +1914,8 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              pipelineIndex);
         }
     } else {
-        // VS is required
-        if (!(pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT)) {
+        // VS is required if this is a "normal" pipeline or is a pre-raster graphics library
+        if (pPipeline->pre_raster_state && !(pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT)) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-stage-00727",
                              "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Vertex Shader required.", pipelineIndex);
         }
@@ -1946,23 +1953,32 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                          pipelineIndex);
     }
 
-    if ((pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT) && !create_info.pInputAssemblyState) {
-        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-02098",
-                         "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pInputAssemblyState.", pipelineIndex);
+    const auto *ia_state = pPipeline->InputAssemblyState();
+    if (!ia_state) {
+        if (!pPipeline->IsGraphicsLibrary()) {
+            // This is a "regular" pipeline
+            if ((pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-02098",
+                                 "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pInputAssemblyState.", pipelineIndex);
+            }
+        } else if (pPipeline->graphics_lib_type == VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT) {
+            // This is a "graphics library"
+            skip |= LogError(device, "VUID-GraphicsLibrary-UNKNOWN",
+                             "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pInputAssemblyState.", pipelineIndex);
+        }
     }
 
     // VK_PRIMITIVE_TOPOLOGY_PATCH_LIST primitive topology is only valid for tessellation pipelines.
     // Mismatching primitive topology and tessellation fails graphics pipeline creation.
-    if (has_control && has_eval &&
-        (!create_info.pInputAssemblyState || create_info.pInputAssemblyState->topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
+    if (has_control && has_eval && (!ia_state || ia_state->topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-00736",
                          "Invalid Pipeline CreateInfo[%" PRIu32
                          "] State: VK_PRIMITIVE_TOPOLOGY_PATCH_LIST must be set as IA topology for "
                          "tessellation pipelines.",
                          pipelineIndex);
     }
-    if (create_info.pInputAssemblyState) {
-        if (create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
+    if (ia_state) {
+        if (ia_state->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
             if (!has_control || !has_eval) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-topology-00737",
                                  "Invalid Pipeline CreateInfo[%" PRIu32
@@ -1972,22 +1988,20 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             }
         }
 
-        if ((create_info.pInputAssemblyState->primitiveRestartEnable == VK_TRUE) &&
-            (create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
+        if ((ia_state->primitiveRestartEnable == VK_TRUE) &&
+            (ia_state->topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST || ia_state->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
             if (IsExtEnabled(device_extensions.vk_ext_primitive_topology_list_restart)) {
-                if (create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
+                if (ia_state->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
                     if (!enabled_features.primitive_topology_list_restart_features.primitiveTopologyPatchListRestart) {
                         skip |= LogError(device, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
                                          "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                                          "]: topology is %s and primitiveRestartEnable is VK_TRUE and the "
                                          "primitiveTopologyPatchListRestart feature is not enabled.",
-                                         pipelineIndex,
-                                         string_VkPrimitiveTopology(create_info.pInputAssemblyState->topology));
+                                         pipelineIndex, string_VkPrimitiveTopology(ia_state->topology));
                     }
                 } else if (!enabled_features.primitive_topology_list_restart_features.primitiveTopologyListRestart) {
                     skip |= LogError(
@@ -1995,40 +2009,39 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                         "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                         "]: topology is %s and primitiveRestartEnable is VK_TRUE and the primitiveTopologyListRestart feature "
                         "is not enabled.",
-                        pipelineIndex, string_VkPrimitiveTopology(create_info.pInputAssemblyState->topology));
+                        pipelineIndex, string_VkPrimitiveTopology(ia_state->topology));
                 }
             } else {
                 skip |= LogError(device, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
                                  "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                                  "]: topology is %s and primitiveRestartEnable is VK_TRUE. It is invalid.",
-                                 pipelineIndex,
-                                 string_VkPrimitiveTopology(create_info.pInputAssemblyState->topology));
+                                 pipelineIndex, string_VkPrimitiveTopology(ia_state->topology));
             }
         }
         if ((enabled_features.core.geometryShader == VK_FALSE) &&
-            (create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY ||
-             create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY)) {
+            (ia_state->topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY ||
+             ia_state->topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY)) {
             skip |= LogError(device, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429",
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                              "]: topology is %s and geometry shaders feature is not enabled. "
                              "It is invalid.",
-                             pipelineIndex, string_VkPrimitiveTopology(create_info.pInputAssemblyState->topology));
+                             pipelineIndex, string_VkPrimitiveTopology(ia_state->topology));
         }
-        if ((enabled_features.core.tessellationShader == VK_FALSE) &&
-            (create_info.pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
+        if ((enabled_features.core.tessellationShader == VK_FALSE) && (ia_state->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
             skip |= LogError(device, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00430",
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                              "]: topology is %s and tessellation shaders feature is not "
                              "enabled. It is invalid.",
-                             pipelineIndex, string_VkPrimitiveTopology(create_info.pInputAssemblyState->topology));
+                             pipelineIndex, string_VkPrimitiveTopology(ia_state->topology));
         }
     }
 
     // If a rasterization state is provided...
-    if (create_info.pRasterizationState) {
-        if ((create_info.pRasterizationState->depthClampEnable == VK_TRUE) && (!enabled_features.core.depthClamp)) {
+    const auto raster_state = pPipeline->RasterizationState();
+    if (raster_state) {
+        if ((raster_state->depthClampEnable == VK_TRUE) && (!enabled_features.core.depthClamp)) {
             skip |= LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-depthClampEnable-00782",
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
                              "]: the depthClamp device feature is disabled: the "
@@ -2037,7 +2050,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              pipelineIndex);
         }
 
-        if (!IsDynamic(pPipeline, VK_DYNAMIC_STATE_DEPTH_BIAS) && (create_info.pRasterizationState->depthBiasClamp != 0.0) &&
+        if (!IsDynamic(pPipeline, VK_DYNAMIC_STATE_DEPTH_BIAS) && (raster_state->depthBiasClamp != 0.0) &&
             (!enabled_features.core.depthBiasClamp)) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00754",
                              "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
@@ -2049,73 +2062,90 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
 
         // If rasterization is enabled...
-        if (create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE) {
-            if ((create_info.pMultisampleState->alphaToOneEnable == VK_TRUE) && (!enabled_features.core.alphaToOne)) {
-                skip |= LogError(device, "VUID-VkPipelineMultisampleStateCreateInfo-alphaToOneEnable-00785",
-                                 "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
-                                 "]: the alphaToOne device feature is disabled: the alphaToOneEnable "
-                                 "member of the VkPipelineMultisampleStateCreateInfo structure must be set to VK_FALSE.",
-                                 pipelineIndex);
+        if (raster_state->rasterizerDiscardEnable == VK_FALSE) {
+            // pMultisampleState can be null for graphics library
+            const bool has_ms_state =
+                !pPipeline->IsGraphicsLibrary() ||
+                ((pPipeline->graphics_lib_type & (VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT |
+                                                  VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT)) != 0);
+            if (has_ms_state) {
+                const auto ms_state = pPipeline->MultisampleState();
+                if (ms_state && (ms_state->alphaToOneEnable == VK_TRUE) && (!enabled_features.core.alphaToOne)) {
+                    skip |= LogError(device, "VUID-VkPipelineMultisampleStateCreateInfo-alphaToOneEnable-00785",
+                                     "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
+                                     "]: the alphaToOne device feature is disabled: the alphaToOneEnable "
+                                     "member of the VkPipelineMultisampleStateCreateInfo structure must be set to VK_FALSE.",
+                                     pipelineIndex);
+                }
             }
 
             // If subpass uses a depth/stencil attachment, pDepthStencilState must be a pointer to a valid structure
-            if (subpass_desc && subpass_desc->pDepthStencilAttachment &&
-                subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
-                if (!create_info.pDepthStencilState) {
-                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06043",
-                                     "Invalid Pipeline CreateInfo[%" PRIu32
-                                     "] State: pDepthStencilState is NULL when rasterization is enabled "
-                                     "and subpass uses a depth/stencil attachment.",
-                                     pipelineIndex);
-
-                } else if (create_info.pDepthStencilState->depthBoundsTestEnable == VK_TRUE) {
-                    if (!enabled_features.core.depthBounds) {
-                        skip |=
-                            LogError(device, "VUID-VkPipelineDepthStencilStateCreateInfo-depthBoundsTestEnable-00598",
-                                     "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
-                                     "]: the depthBounds device feature is disabled: the "
-                                     "depthBoundsTestEnable member of the VkPipelineDepthStencilStateCreateInfo structure must be "
-                                     "set to VK_FALSE.",
-                                     pipelineIndex);
-                    }
-
-                    // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
-                    if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted) &&
-                        !IsDynamic(pPipeline, VK_DYNAMIC_STATE_DEPTH_BOUNDS)) {
-                        const float minDepthBounds = create_info.pDepthStencilState->minDepthBounds;
-                        const float maxDepthBounds = create_info.pDepthStencilState->maxDepthBounds;
-                        // Also VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755
-                        if (!(minDepthBounds >= 0.0) || !(minDepthBounds <= 1.0)) {
-                            skip |=
-                                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510",
-                                         "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
-                                         "]: VK_EXT_depth_range_unrestricted extension "
-                                         "is not enabled, VK_DYNAMIC_STATE_DEPTH_BOUNDS is not used, depthBoundsTestEnable is "
-                                         "true, and pDepthStencilState::minDepthBounds (=%f) is not within the [0.0, 1.0] range.",
-                                         pipelineIndex, minDepthBounds);
+            const bool has_ds_state =
+                !pPipeline->IsGraphicsLibrary() ||
+                ((pPipeline->graphics_lib_type & (VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT)) != 0);
+            if (has_ds_state) {
+                if (subpass_desc && subpass_desc->pDepthStencilAttachment &&
+                    subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
+                    if (!ds_state) {
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06043",
+                                         "Invalid Pipeline CreateInfo[%" PRIu32
+                                         "] State: pDepthStencilState is NULL when rasterization is enabled "
+                                         "and subpass uses a depth/stencil attachment.",
+                                         pipelineIndex);
+                    } else if (ds_state->depthBoundsTestEnable == VK_TRUE) {
+                        if (!enabled_features.core.depthBounds) {
+                            skip |= LogError(
+                                device, "VUID-VkPipelineDepthStencilStateCreateInfo-depthBoundsTestEnable-00598",
+                                "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
+                                "]: the depthBounds device feature is disabled: the "
+                                "depthBoundsTestEnable member of the VkPipelineDepthStencilStateCreateInfo structure must be "
+                                "set to VK_FALSE.",
+                                pipelineIndex);
                         }
-                        if (!(maxDepthBounds >= 0.0) || !(maxDepthBounds <= 1.0)) {
-                            skip |=
-                                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510",
-                                         "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
-                                         "]: VK_EXT_depth_range_unrestricted extension "
-                                         "is not enabled, VK_DYNAMIC_STATE_DEPTH_BOUNDS is not used, depthBoundsTestEnable is "
-                                         "true, and pDepthStencilState::maxDepthBounds (=%f) is not within the [0.0, 1.0] range.",
-                                         pipelineIndex, maxDepthBounds);
+
+                        // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
+                        if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted) &&
+                            !IsDynamic(pPipeline, VK_DYNAMIC_STATE_DEPTH_BOUNDS)) {
+                            const float minDepthBounds = ds_state->minDepthBounds;
+                            const float maxDepthBounds = ds_state->maxDepthBounds;
+                            // Also VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755
+                            if (!(minDepthBounds >= 0.0) || !(minDepthBounds <= 1.0)) {
+                                skip |= LogError(
+                                    device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510",
+                                    "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
+                                    "]: VK_EXT_depth_range_unrestricted extension "
+                                    "is not enabled, VK_DYNAMIC_STATE_DEPTH_BOUNDS is not used, depthBoundsTestEnable is "
+                                    "true, and pDepthStencilState::minDepthBounds (=%f) is not within the [0.0, 1.0] range.",
+                                    pipelineIndex, minDepthBounds);
+                            }
+                            if (!(maxDepthBounds >= 0.0) || !(maxDepthBounds <= 1.0)) {
+                                skip |= LogError(
+                                    device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510",
+                                    "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32
+                                    "]: VK_EXT_depth_range_unrestricted extension "
+                                    "is not enabled, VK_DYNAMIC_STATE_DEPTH_BOUNDS is not used, depthBoundsTestEnable is "
+                                    "true, and pDepthStencilState::maxDepthBounds (=%f) is not within the [0.0, 1.0] range.",
+                                    pipelineIndex, maxDepthBounds);
+                            }
                         }
                     }
                 }
             }
 
             // If subpass uses color attachments, pColorBlendState must be valid pointer
-            if (subpass_desc) {
+            const bool has_color_blend_state =
+                !pPipeline->IsGraphicsLibrary() ||
+                ((pPipeline->graphics_lib_type & (VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT)) != 0);
+            if (has_color_blend_state && subpass_desc) {
                 uint32_t color_attachment_count = 0;
                 for (uint32_t i = 0; i < subpass_desc->colorAttachmentCount; ++i) {
                     if (subpass_desc->pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
                         ++color_attachment_count;
                     }
                 }
-                if (color_attachment_count > 0 && create_info.pColorBlendState == nullptr) {
+
+                if (pPipeline->fragment_output_state && (color_attachment_count > 0) &&
+                    !pPipeline->fragment_output_state->color_blend_state) {
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06044",
                                      "Invalid Pipeline CreateInfo[%" PRIu32
                                      "] State: pColorBlendState is NULL when rasterization is enabled and "
@@ -2149,7 +2179,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
 
         auto provoking_vertex_state_ci =
-            lvl_find_in_chain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(create_info.pRasterizationState->pNext);
+            lvl_find_in_chain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(raster_state->pNext);
         if (provoking_vertex_state_ci &&
             provoking_vertex_state_ci->provokingVertexMode == VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT &&
             !enabled_features.provoking_vertex_features.provokingVertexLast) {
@@ -2158,8 +2188,8 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                 "provokingVertexLast feature is not enabled.");
         }
 
-        const auto rasterization_state_stream_ci = LvlFindInChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(
-            pPipeline->create_info.graphics.pRasterizationState->pNext);
+        const auto rasterization_state_stream_ci =
+            LvlFindInChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(raster_state->pNext);
         if (rasterization_state_stream_ci) {
             if (!enabled_features.transform_feedback_features.geometryStreams) {
                 skip |= LogError(device, "VUID-VkPipelineRasterizationStateStreamCreateInfoEXT-geometryStreams-02324",
@@ -2189,7 +2219,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
 
         const auto rasterization_conservative_state_ci =
-            LvlFindInChain<VkPipelineRasterizationConservativeStateCreateInfoEXT>(create_info.pRasterizationState->pNext);
+            LvlFindInChain<VkPipelineRasterizationConservativeStateCreateInfoEXT>(raster_state->pNext);
         if (rasterization_conservative_state_ci) {
             if (rasterization_conservative_state_ci->extraPrimitiveOverestimationSize < 0.0f ||
                 rasterization_conservative_state_ci->extraPrimitiveOverestimationSize >
@@ -2206,16 +2236,25 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
     }
 
-    if ((pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT) && !create_info.pVertexInputState &&
-        !IsDynamic(pPipeline, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
-        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-02097",
-                         "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pVertexInputState.", pipelineIndex);
+    const auto vi_state = pPipeline->InputState();
+    if (!vi_state) {
+        if (!pPipeline->IsGraphicsLibrary()) {
+            // This is a "regular" pipeline, so vertex input state is required if a vertex stage is present
+            if ((pPipeline->active_shaders & VK_SHADER_STAGE_VERTEX_BIT) &&
+                !IsDynamic(pPipeline, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-02097",
+                                 "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pVertexInputState.", pipelineIndex);
+            }
+        } else if (pPipeline->graphics_lib_type == VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT) {
+            // This "pipeline" is a graphics library
+            skip |= LogError(device, "VUID-GraphicsLibrary-VertexInput-UNKNOWN",
+                             "Invalid Pipeline CreateInfo[%" PRIu32 "] State: Missing pVertexInputState.", pipelineIndex);
+        }
     }
 
-    auto vi = create_info.pVertexInputState;
-    if (vi != NULL) {
-        for (uint32_t j = 0; j < vi->vertexAttributeDescriptionCount; j++) {
-            VkFormat format = vi->pVertexAttributeDescriptions[j].format;
+    if (vi_state) {
+        for (uint32_t j = 0; j < vi_state->vertexAttributeDescriptionCount; j++) {
+            VkFormat format = vi_state->pVertexAttributeDescriptions[j].format;
             // Internal call to get format info.  Still goes through layers, could potentially go directly to ICD.
             VkFormatProperties properties;
             DispatchGetPhysicalDeviceFormatProperties(physical_device, format, &properties);
@@ -2229,13 +2268,13 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
     }
 
-    if (subpass_desc && create_info.pMultisampleState) {
-        const safe_VkPipelineMultisampleStateCreateInfo *multisample_state = create_info.pMultisampleState;
-        auto accum_color_samples = [subpass_desc, pPipeline](uint32_t &samples) {
+    const auto *multisample_state = pPipeline->MultisampleState();
+    if (subpass_desc && multisample_state) {
+        auto accum_color_samples = [subpass_desc, &rp_state](uint32_t &samples) {
             for (uint32_t i = 0; i < subpass_desc->colorAttachmentCount; i++) {
                 const auto attachment = subpass_desc->pColorAttachments[i].attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
-                    samples |= static_cast<uint32_t>(pPipeline->rp_state->createInfo.pAttachments[attachment].samples);
+                    samples |= static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
                 }
             }
         };
@@ -2250,7 +2289,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             if (subpass_desc->pDepthStencilAttachment &&
                 subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                 const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
-                subpass_num_samples |= static_cast<uint32_t>(pPipeline->rp_state->createInfo.pAttachments[attachment].samples);
+                subpass_num_samples |= static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
             }
 
             // subpass_num_samples is 0 when the subpass has no attachments or if all attachments are VK_ATTACHMENT_UNUSED.
@@ -2269,17 +2308,15 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             for (uint32_t i = 0; i < subpass_desc->colorAttachmentCount; ++i) {
                 if (subpass_desc->pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
                     max_sample_count = std::max(
-                        max_sample_count,
-                        pPipeline->rp_state->createInfo.pAttachments[subpass_desc->pColorAttachments[i].attachment].samples);
+                        max_sample_count, rp_state->createInfo.pAttachments[subpass_desc->pColorAttachments[i].attachment].samples);
                 }
             }
             if (subpass_desc->pDepthStencilAttachment &&
                 subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                 max_sample_count = std::max(
-                    max_sample_count,
-                    pPipeline->rp_state->createInfo.pAttachments[subpass_desc->pDepthStencilAttachment->attachment].samples);
+                    max_sample_count, rp_state->createInfo.pAttachments[subpass_desc->pDepthStencilAttachment->attachment].samples);
             }
-            if ((create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE) &&
+            if ((raster_state->rasterizerDiscardEnable == VK_FALSE) &&
                 (max_sample_count != static_cast<VkSampleCountFlagBits>(0)) &&
                 (multisample_state->rasterizationSamples != max_sample_count)) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-subpass-01505",
@@ -2287,7 +2324,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                                  "].pMultisampleState->rasterizationSamples (%s) != max "
                                  "attachment samples (%s) used in subpass %u.",
                                  pipelineIndex, string_VkSampleCountFlagBits(multisample_state->rasterizationSamples),
-                                 string_VkSampleCountFlagBits(max_sample_count), create_info.subpass);
+                                 string_VkSampleCountFlagBits(max_sample_count), subpass);
             }
         }
 
@@ -2300,13 +2337,12 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             if (subpass_desc->pDepthStencilAttachment &&
                 subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                 const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
-                const uint32_t subpass_depth_samples =
-                    static_cast<uint32_t>(pPipeline->rp_state->createInfo.pAttachments[attachment].samples);
+                const uint32_t subpass_depth_samples = static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
 
-                if (create_info.pDepthStencilState) {
-                    const bool ds_test_enabled = (create_info.pDepthStencilState->depthTestEnable == VK_TRUE) ||
-                                                 (create_info.pDepthStencilState->depthBoundsTestEnable == VK_TRUE) ||
-                                                 (create_info.pDepthStencilState->stencilTestEnable == VK_TRUE);
+                if (ds_state) {
+                    const bool ds_test_enabled = (ds_state->depthTestEnable == VK_TRUE) ||
+                                                 (ds_state->depthBoundsTestEnable == VK_TRUE) ||
+                                                 (ds_state->stencilTestEnable == VK_TRUE);
 
                     if (ds_test_enabled && (!IsPowerOfTwo(subpass_depth_samples) || (raster_samples != subpass_depth_samples))) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-subpass-01411",
@@ -2367,7 +2403,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             if (subpass_desc->pDepthStencilAttachment &&
                 subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                 const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
-                subpass_depth_samples = static_cast<uint32_t>(pPipeline->rp_state->createInfo.pAttachments[attachment].samples);
+                subpass_depth_samples = static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
             }
 
             if (multisample_state && IsPowerOfTwo(subpass_color_samples) &&
@@ -2420,7 +2456,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                     const auto& color_attachment_ref =
                         subpass_desc->pColorAttachments[coverage_to_color_state->coverageToColorLocation];
                     if (color_attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                        const auto& color_attachment = pPipeline->rp_state->createInfo.pAttachments[color_attachment_ref.attachment];
+                        const auto &color_attachment = rp_state->createInfo.pAttachments[color_attachment_ref.attachment];
 
                         switch (color_attachment.format) {
                             case VK_FORMAT_R8_UINT:
@@ -2522,7 +2558,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                 const auto attachment = subpass_desc->pInputAttachments[i].attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
                     subpass_input_attachment_samples |=
-                        static_cast<uint32_t>(pPipeline->rp_state->createInfo.pAttachments[attachment].samples);
+                        static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
                 }
             }
 
@@ -2549,7 +2585,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
     }
 
-    skip |= ValidatePipelineCacheControlFlags(create_info.flags, pipelineIndex, "vkCreateGraphicsPipelines",
+    skip |= ValidatePipelineCacheControlFlags(pPipeline->GetPipelineCreateFlags(), pipelineIndex, "vkCreateGraphicsPipelines",
                                               "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
 
     // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03378
@@ -2605,7 +2641,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
     }
 
     const VkPipelineFragmentShadingRateStateCreateInfoKHR *fragment_shading_rate_state =
-        LvlFindInChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(create_info.pNext);
+        LvlFindInChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(pPipeline->PNext());
 
     if (fragment_shading_rate_state && !IsDynamic(pPipeline, VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR)) {
         const char *struct_name = "VkPipelineFragmentShadingRateStateCreateInfoKHR";
@@ -2715,7 +2751,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
         }
     }
 
-    const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(create_info.pNext);
+    const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pPipeline->PNext());
     if (discard_rectangle_state) {
         if (discard_rectangle_state->discardRectangleCount > phys_dev_ext_props.discard_rectangle_props.maxDiscardRectangles) {
             skip |= LogError(
@@ -2746,14 +2782,14 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                          pipelineIndex);
     }
 
-    const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(create_info.pNext);
+    const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pPipeline->PNext());
     if (rendering_struct) {
         const bool has_rasterization =
-            create_info.pRasterizationState && (create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE);
+            pPipeline->RasterizationState() && (pPipeline->RasterizationState()->rasterizerDiscardEnable == VK_FALSE);
         if (has_rasterization &&
             ((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
              (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED)) &&
-            (create_info.pDepthStencilState == nullptr)) {
+            !pPipeline->DepthStencilState()) {
             skip |= LogError(
                 device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06053",
                 "vkCreateGraphicsPipelines(): Pipeline %" PRIu32
@@ -2762,7 +2798,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                 string_VkFormat(rendering_struct->stencilAttachmentFormat));
         }
 
-        if (has_rasterization && (rendering_struct->colorAttachmentCount != 0) && (create_info.pColorBlendState == nullptr)) {
+        if (has_rasterization && (rendering_struct->colorAttachmentCount != 0) && !pPipeline->ColorBlendState()) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06054",
                              "vkCreateGraphicsPipelines(): Pipeline %" PRIu32
                              " has VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32
@@ -2789,12 +2825,12 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              pipelineIndex, rendering_struct->viewMask);
         }
 
-        if ((pPipeline->create_info.graphics.pColorBlendState != nullptr) &&
-            (rendering_struct->colorAttachmentCount != pPipeline->create_info.graphics.pColorBlendState->attachmentCount)) {
+        if (color_blend_state && (rendering_struct->colorAttachmentCount != color_blend_state->attachmentCount)) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06060",
-                "vkCreateGraphicsPipelines() Pipeline %" PRIu32 " interface pColorBlendState->attachmentCount %" PRIu32 " and "
-                "VkPipelineRenderingCreateInfoKHR->colorAttachmentCount %" PRIu32 " must be equal",
-                pipelineIndex, rendering_struct->colorAttachmentCount, pPipeline->create_info.graphics.pColorBlendState->attachmentCount);
+                             "vkCreateGraphicsPipelines() Pipeline %" PRIu32 " interface pColorBlendState->attachmentCount %" PRIu32
+                             " and "
+                             "VkPipelineRenderingCreateInfoKHR->colorAttachmentCount %" PRIu32 " must be equal",
+                             pipelineIndex, rendering_struct->colorAttachmentCount, color_blend_state->attachmentCount);
         }
 
         for (uint32_t color_index = 0; color_index < rendering_struct->colorAttachmentCount; color_index++) {
@@ -2802,9 +2838,8 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
             if (color_format != VK_FORMAT_UNDEFINED) {
                 VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(color_format);
                 if (((format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0) &&
-                    (pPipeline->create_info.graphics.pColorBlendState &&
-                     color_index < pPipeline->create_info.graphics.pColorBlendState->attachmentCount &&
-                     pPipeline->create_info.graphics.pColorBlendState->pAttachments[color_index].blendEnable != VK_FALSE)) {
+                    (color_blend_state && (color_index < color_blend_state->attachmentCount) &&
+                     (color_blend_state->pAttachments[color_index].blendEnable != VK_FALSE))) {
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06062",
                         "vkCreateGraphicsPipelines(): vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
                         "]: pColorBlendState->blendEnable must be false ",
@@ -5827,9 +5862,9 @@ bool CoreChecks::ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPE
 
             // Find the corresponding binding description and validate input rate setting
             bool failed_01871 = true;
-            for (size_t k = 0; k < pipe_state->vertex_binding_descriptions_.size(); k++) {
-                if ((vibdd->binding == pipe_state->vertex_binding_descriptions_[k].binding) &&
-                    (VK_VERTEX_INPUT_RATE_INSTANCE == pipe_state->vertex_binding_descriptions_[k].inputRate)) {
+            for (size_t k = 0; k < pipe_state->vertex_input_state->binding_descriptions.size(); k++) {
+                if ((vibdd->binding == pipe_state->vertex_input_state->binding_descriptions[k].binding) &&
+                    (VK_VERTEX_INPUT_RATE_INSTANCE == pipe_state->vertex_input_state->binding_descriptions[k].inputRate)) {
                     failed_01871 = false;
                     break;
                 }
@@ -5887,9 +5922,9 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
     create_graphics_pipeline_api_state *cgpl_state = reinterpret_cast<create_graphics_pipeline_api_state *>(cgpl_state_data);
 
     for (uint32_t i = 0; i < count; i++) {
-        if (pCreateInfos[i].renderPass == VK_NULL_HANDLE) {
-            if ((api_version < VK_API_VERSION_1_3) && (!enabled_features.core13.dynamicRendering) &&
-                (pCreateInfos[i].renderPass == VK_NULL_HANDLE)) {
+        const auto &pipe_state = cgpl_state->pipe_state[i];
+        if (!pipe_state->RenderPassState()) {
+            if ((api_version < VK_API_VERSION_1_3) && (!enabled_features.core13.dynamicRendering)) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06051",
                                  "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32 "]: renderpass must not be VK_NULL_HANDLE.", i);
                 return true;
@@ -5993,7 +6028,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
     auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
     for (uint32_t i = 0; i < count; i++) {
         PIPELINE_STATE *pipeline = crtpl_state->pipe_state[i].get();
-        const auto &create_info = pipeline->create_info.raytracing;
+        const auto &create_info = pipeline->GetUnifiedCreateInfo().raytracing;
         if (create_info.flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
             if (create_info.basePipelineIndex != -1) {
@@ -6027,7 +6062,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
     auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_khr_api_state *>(crtpl_state_data);
     for (uint32_t i = 0; i < count; i++) {
         PIPELINE_STATE *pipeline = crtpl_state->pipe_state[i].get();
-        const auto &create_info = pipeline->create_info.raytracing;
+        const auto &create_info = pipeline->GetUnifiedCreateInfo().raytracing;
         if (create_info.flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
             if (create_info.basePipelineIndex != -1) {
@@ -6059,8 +6094,8 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 {"VUID-VkRayTracingPipelineCreateInfoKHR-flags-04723", VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR},
             };
             for (uint32_t j = 0; j < create_info.pLibraryInfo->libraryCount; ++j) {
-                auto lib = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[j]);
-                if ((lib->create_info.raytracing.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
+                const auto lib = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[j]);
+                if ((lib->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
                     skip |= LogError(
                         device, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-03381",
                                      "vkCreateRayTracingPipelinesKHR(): pCreateInfo[%" PRIu32 "].pLibraryInfo->pLibraries[%" PRIu32
@@ -6068,7 +6103,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 }
                 for (const auto &pair : vuid_map) {
                     if (create_info.flags & pair.second) {
-                        if ((lib->create_info.raytracing.flags & pair.second) == 0) {
+                        if ((lib->GetPipelineCreateFlags() & pair.second) == 0) {
                             skip |= LogError(
                                 device, pair.first,
                                 "vkCreateRayTracingPipelinesKHR(): pCreateInfo[%" PRIu32
@@ -7984,8 +8019,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE *cb_st
             skip |= LogError(device, "VUID-vkCmdBindPipeline-commandBuffer-04808",
                 "Graphics pipeline incompatible with viewport/scissor inheritance.");
         }
-        const auto &create_info = pipeline_state->create_info.graphics;
-        const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(create_info.pNext);
+        const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline_state->PNext());
         if (discard_rectangle_state && discard_rectangle_state->discardRectangleCount != 0) {
             if (!IsDynamic(pipeline_state, VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
                 skip |= LogError(device, "VUID-vkCmdBindPipeline-commandBuffer-04809",
@@ -8046,11 +8080,11 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                 if (last_bound_it.pipeline_state) {
                     auto last_bound_provoking_vertex_state_ci =
                         LvlFindInChain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(
-                            last_bound_it.pipeline_state->create_info.graphics.pRasterizationState->pNext);
+                            last_bound_it.pipeline_state->RasterizationState()->pNext);
 
                     auto current_provoking_vertex_state_ci =
                         LvlFindInChain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(
-                            pipeline_state->create_info.graphics.pRasterizationState->pNext);
+                            pipeline_state->RasterizationState()->pNext);
 
                     if (last_bound_provoking_vertex_state_ci && !current_provoking_vertex_state_ci) {
                         skip |= LogError(pipeline, "VUID-vkCmdBindPipeline-pipelineBindPoint-04881",
@@ -8081,8 +8115,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             }
 
             if (cb_state->activeRenderPass && phys_dev_ext_props.sample_locations_props.variableSampleLocations == VK_FALSE) {
-                const auto *sample_locations =
-                    LvlFindInChain<VkPipelineSampleLocationsStateCreateInfoEXT>(pipeline_state->create_info.graphics.pNext);
+                const auto *sample_locations = LvlFindInChain<VkPipelineSampleLocationsStateCreateInfoEXT>(pipeline_state->PNext());
                 if (sample_locations && sample_locations->sampleLocationsEnable == VK_TRUE &&
                     !IsDynamic(pipeline_state.get(), VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT)) {
                     const VkRenderPassSampleLocationsBeginInfoEXT *sample_locations_begin_info =
@@ -17091,7 +17124,7 @@ bool CoreChecks::PreCallValidateCmdSetSampleLocationsEXT(VkCommandBuffer command
     const auto *pipe = cb_state->lastBound[lv_bind_point].pipeline_state;
     if (pipe != nullptr) {
         // Check same error with different log messages
-        const safe_VkPipelineMultisampleStateCreateInfo *multisample_state = pipe->create_info.graphics.pMultisampleState;
+        const auto *multisample_state = pipe->MultisampleState();
         if (multisample_state == nullptr) {
             skip |= LogError(cb_state->commandBuffer(), "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
                              "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel must be equal to "
@@ -17748,7 +17781,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(VkCom
 }
 
 uint32_t CoreChecks::CalcTotalShaderGroupCount(const PIPELINE_STATE *pipelineState) const {
-    const auto &create_info = pipelineState->create_info.raytracing;
+    const auto &create_info = pipelineState->GetUnifiedCreateInfo().raytracing;
     uint32_t total = create_info.groupCount;
 
     if (create_info.pLibraryInfo) {
@@ -17806,7 +17839,7 @@ bool CoreChecks::PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR(
     if (!pipeline_state) {
         return skip;
     }
-    const auto &create_info = pipeline_state->create_info.raytracing;
+    const auto &create_info = pipeline_state->GetUnifiedCreateInfo().raytracing;
     if (firstGroup >= create_info.groupCount) {
         skip |= LogError(device, "VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-firstGroup-04051",
                          "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR: firstGroup must be less than the number of shader "
@@ -18492,7 +18525,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
             skip |= LogError(device, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-pipeline-04622",
                              "vkGetRayTracingShaderGroupStackSizeKHR: Pipeline must be a ray-tracing pipeline, but is a %s pipeline.",
                              GetPipelineTypeName(pipeline_state->GetPipelineType()));
-        } else if (group >= pipeline_state->create_info.raytracing.groupCount) {
+        } else if (group >= pipeline_state->GetUnifiedCreateInfo().raytracing.groupCount) {
             skip |=
                 LogError(device, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-group-03608",
                          "vkGetRayTracingShaderGroupStackSizeKHR: The value of group must be less than the number of shader groups "

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -580,35 +580,35 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
                                                        bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* module_state,
-                                              VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
+                                              safe_VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
                                               spirv_inst_iter entrypoint) const;
     bool ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const* module_state, const spirv_inst_iter& insn) const;
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* module_state, VkShaderStageFlagBits stage,
                                             spirv_inst_iter& insn) const;
     bool ValidateMemoryScope(SHADER_MODULE_STATE const* module_state, const spirv_inst_iter& insn) const;
-    bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
-    bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
-    bool ValidateShaderSubgroupSizeControl(VkPipelineShaderStageCreateInfo const* pStage) const;
+    bool ValidateShaderSubgroupSizeControl(safe_VkPipelineShaderStageCreateInfo const* pStage) const;
     bool ValidateAtomicsTypes(SHADER_MODULE_STATE const* module_state) const;
     bool ValidateExecutionModes(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
-    bool ValidateViConsistency(VkPipelineVertexInputStateCreateInfo const* vi) const;
-    bool ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo const* vi, SHADER_MODULE_STATE const* module_state,
+    bool ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const* vi) const;
+    bool ValidateViAgainstVsInputs(safe_VkPipelineVertexInputStateCreateInfo const* vi, SHADER_MODULE_STATE const* module_state,
                                    spirv_inst_iter entrypoint) const;
     bool ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint,
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
     bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint,
                                                             PIPELINE_STATE const* pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* module_state,
-                                   VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
+                                   safe_VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
     bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;
-    bool ValidateSpecializations(VkPipelineShaderStageCreateInfo const* info) const;
+    bool ValidateSpecializations(safe_VkPipelineShaderStageCreateInfo const* info) const;
     bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure, const char* vuid) const;
     bool RequireFeature(VkBool32 feature, char const* feature_name, const char* vuid) const;
     bool RequireApiVersion(uint32_t version, const char* vuid) const;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -1009,8 +1009,9 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const auto *pipeline_state = cb_node->lastBound[lv_bind_point].pipeline_state;
     if (pipeline_state) {
-        if (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index) {
-            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout(), desc_set_bind_index, 1,
+        const auto &pipeline_layout = pipeline_state->PipelineLayoutState();
+        if (pipeline_layout->set_layouts.size() <= desc_set_bind_index) {
+            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_layout->layout(), desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }
         // Record buffer and memory info in CB state tracking

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -99,7 +99,7 @@ typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 
 struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
-    const VkPipelineShaderStageCreateInfo *create_info;
+    const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
     spirv_inst_iter entrypoint;
     layer_data::unordered_set<uint32_t> accessible_ids;
@@ -109,7 +109,7 @@ struct PipelineStageState {
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;
 
-    PipelineStageState(const VkPipelineShaderStageCreateInfo *stage, std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
+    PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *stage, std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
 };
 
 class PIPELINE_STATE : public BASE_NODE {
@@ -126,7 +126,7 @@ class PIPELINE_STATE : public BASE_NODE {
                     use_depth_stencil = (dynamic_rendering->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
                                         (dynamic_rendering->stencilAttachmentFormat != VK_FORMAT_UNDEFINED);
                 }
-            } else {
+            } else if (rpstate) {
                 use_color = rpstate->UsesColorAttachment(ci->subpass);
                 use_depth_stencil = rpstate->UsesDepthStencilAttachment(ci->subpass);
             }
@@ -159,12 +159,25 @@ class PIPELINE_STATE : public BASE_NODE {
         safe_VkComputePipelineCreateInfo compute;
         safe_VkRayTracingPipelineCreateInfoCommon raytracing;
     };
+
+  protected:
+    // NOTE: The style guide suggests private data appear at the end, but we need this populated first, so placing it here
     const CreateInfo create_info;
-    std::shared_ptr<const PIPELINE_LAYOUT_STATE> pipeline_layout;
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+
+  public:
+    VkGraphicsPipelineLibraryFlagsEXT graphics_lib_type = static_cast<VkGraphicsPipelineLibraryFlagsEXT>(0);
+    // State split up based on library types
+    const std::shared_ptr<VertexInputState> vertex_input_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT
+    const std::shared_ptr<PreRasterState> pre_raster_state;      // VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT
+    const std::shared_ptr<FragmentShaderState> fragment_shader_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT
+    const std::shared_ptr<FragmentOutputState>
+        fragment_output_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT
+
     // Additional metadata needed by pipeline_state initialization and validation
     using StageStateVec = std::vector<PipelineStageState>;
     const StageStateVec stage_state;
+
+    const layer_data::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
 
     // Capture which slots (set#->bindings) are actually used by the shaders of this pipeline
     using ActiveSlotMap = layer_data::unordered_map<uint32_t, BindingReqMap>;
@@ -174,36 +187,9 @@ class PIPELINE_STATE : public BASE_NODE {
     const ActiveSlotMap active_slots;
     const uint32_t max_active_slot = 0;  // the highest set number in active_slots for pipeline layout compatibility checks
 
-    const layer_data::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
-    // Vtx input info (if any)
-    using VertexBindingVector = std::vector<VkVertexInputBindingDescription>;
-    const VertexBindingVector vertex_binding_descriptions_;
-
-    using VertexAttrVector = std::vector<VkVertexInputAttributeDescription>;
-    const VertexAttrVector vertex_attribute_descriptions_;
-
-    using VertexAttrAlignmentVector = std::vector<VkDeviceSize>;
-    const VertexAttrAlignmentVector vertex_attribute_alignments_;
-
-    using VertexBindingIndexMap = layer_data::unordered_map<uint32_t, uint32_t>;
-    const VertexBindingIndexMap vertex_binding_to_index_map_;
-
-    using AttachmentVector = std::vector<VkPipelineColorBlendAttachmentState>;
-    const AttachmentVector attachments;
-
-    const bool blend_constants_enabled;  // Blend constants enabled for any attachments
-    const bool sample_location_enabled;
     // Flag of which shader stages are active for this pipeline
     const uint32_t active_shaders = 0;
     const VkPrimitiveTopology topology_at_rasterizer;
-
-    VkGraphicsPipelineLibraryFlagsEXT graphics_lib_type = static_cast<VkGraphicsPipelineLibraryFlagsEXT>(0);
-    // State split up based on library types
-    const std::shared_ptr<VertexInputState> vertex_input_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT
-    const std::shared_ptr<PreRasterState> pre_raster_state;      // VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT
-    const std::shared_ptr<FragmentShaderState> fragment_shader_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT
-    const std::shared_ptr<FragmentOutputState>
-        fragment_output_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT
 
     PIPELINE_STATE(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                    std::shared_ptr<const RENDER_PASS_STATE> &&rpstate, std::shared_ptr<const PIPELINE_LAYOUT_STATE> &&layout);
@@ -274,7 +260,148 @@ class PIPELINE_STATE : public BASE_NODE {
         return {};
     }
 
-  private:
+    const std::shared_ptr<const RENDER_PASS_STATE> RenderPassState() const {
+        // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
+        if (pre_raster_state && pre_raster_state->rp_state) {
+            return pre_raster_state->rp_state;
+        } else if (fragment_shader_state && fragment_shader_state->rp_state) {
+            return fragment_shader_state->rp_state;
+        } else if (fragment_output_state && fragment_output_state->rp_state) {
+            return fragment_output_state->rp_state;
+        }
+        return rp_state;
+    }
+
+    const std::shared_ptr<const PIPELINE_LAYOUT_STATE> PipelineLayoutState() const {
+        // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
+        if (merged_graphics_layout) {
+            return merged_graphics_layout;
+        } else if (pre_raster_state) {
+            return pre_raster_state->pipeline_layout;
+        } else if (fragment_shader_state) {
+            return fragment_shader_state->pipeline_layout;
+        }
+        return merged_graphics_layout;
+    }
+
+    const std::shared_ptr<const PIPELINE_LAYOUT_STATE> PreRasterPipelineLayoutState() const {
+        if (pre_raster_state) {
+            return pre_raster_state->pipeline_layout;
+        }
+        return merged_graphics_layout;
+    }
+
+    const std::shared_ptr<const PIPELINE_LAYOUT_STATE> FragmentShaderPipelineLayoutState() const {
+        if (fragment_shader_state) {
+            return fragment_shader_state->pipeline_layout;
+        }
+        return merged_graphics_layout;
+    }
+
+    const safe_VkPipelineMultisampleStateCreateInfo *MultisampleState() const {
+        // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
+        if (fragment_shader_state) {
+            return fragment_shader_state->ms_state.get();
+        } else if (fragment_output_state) {
+            return fragment_output_state->ms_state.get();
+        }
+        return nullptr;
+    }
+
+    const safe_VkPipelineRasterizationStateCreateInfo *RasterizationState() const {
+        // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
+        if (pre_raster_state) {
+            return pre_raster_state->raster_state;
+        }
+        return nullptr;
+    }
+
+    const safe_VkPipelineViewportStateCreateInfo *ViewportState() const {
+        // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
+        if (pre_raster_state) {
+            return pre_raster_state->viewport_state;
+        }
+        return nullptr;
+    }
+
+    const safe_VkPipelineColorBlendStateCreateInfo *ColorBlendState() const {
+        if (fragment_output_state) {
+            return fragment_output_state->color_blend_state.get();
+        }
+        return nullptr;
+    }
+
+    const safe_VkPipelineVertexInputStateCreateInfo *InputState() const {
+        if (vertex_input_state) {
+            return vertex_input_state->input_state;
+        }
+        return nullptr;
+    }
+
+    const safe_VkPipelineInputAssemblyStateCreateInfo *InputAssemblyState() const {
+        if (vertex_input_state) {
+            return vertex_input_state->input_assembly_state;
+        }
+        return nullptr;
+    }
+
+    uint32_t Subpass() const { return create_info.graphics.subpass; }
+
+    const FragmentOutputState::AttachmentVector &Attachments() const {
+        if (fragment_output_state) {
+            return fragment_output_state->attachments;
+        }
+        static FragmentOutputState::AttachmentVector empty_vec = {};
+        return empty_vec;
+    }
+
+    const safe_VkPipelineDepthStencilStateCreateInfo *DepthStencilState() const {
+        if (fragment_shader_state) {
+            return fragment_shader_state->ds_state.get();
+        }
+        return nullptr;
+    }
+
+    bool BlendConstantsEnabled() const { return fragment_output_state ? fragment_output_state->blend_constants_enabled : false; }
+
+    bool SampleLocationEnabled() const { return fragment_output_state ? fragment_output_state->sample_location_enabled : false; }
+
+    VkPipeline BasePipeline() const { return create_info.graphics.basePipelineHandle; }
+
+    int32_t BasePipelineIndex() const { return create_info.graphics.basePipelineIndex; }
+
+    const safe_VkPipelineDynamicStateCreateInfo *DynamicState() const {
+        // TODO Each library can contain its own dynamic state (apparently?). Which one should be returned here? Union?
+        return create_info.graphics.pDynamicState;
+    }
+
+    layer_data::span<const safe_VkPipelineShaderStageCreateInfo> GetShaderStages() const {
+        switch (create_info.graphics.sType) {
+            case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
+                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.graphics.pStages,
+                                                                                    create_info.graphics.stageCount};
+            case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
+                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{&create_info.compute.stage, 1};
+            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV:
+                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
+                                                                                    create_info.raytracing.stageCount};
+            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
+                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
+                                                                                    create_info.raytracing.stageCount};
+            default:
+                assert(false);
+                return {};
+        }
+    }
+
+    const CreateInfo &GetUnifiedCreateInfo() const { return create_info; }
+
+    const void *PNext() const { return create_info.graphics.pNext; }
+
+    static ActiveSlotMap GetActiveSlots(const StageStateVec &stage_states);
+    static StageStateVec GetStageStates(const ValidationStateTracker &state_data, const PIPELINE_STATE &pipe_state);
+
+  protected:
     static std::shared_ptr<VertexInputState> CreateVertexInputState(const ValidationStateTracker &state,
                                                                     const safe_VkGraphicsPipelineCreateInfo &create_info);
     static std::shared_ptr<PreRasterState> CreatePreRasterState(const ValidationStateTracker &state,
@@ -285,6 +412,11 @@ class PIPELINE_STATE : public BASE_NODE {
     static std::shared_ptr<FragmentOutputState> CreateFragmentOutputState(
         const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
         const safe_VkGraphicsPipelineCreateInfo &safe_create_info);
+
+    // Render pass state for dynamic rendering, etc.
+    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    // Merged layouts
+    std::shared_ptr<const PIPELINE_LAYOUT_STATE> merged_graphics_layout;
 };
 
 template <>

--- a/layers/pipeline_sub_state.cpp
+++ b/layers/pipeline_sub_state.cpp
@@ -207,3 +207,28 @@ bool FragmentOutputState::IsBlendConstantsEnabled(const AttachmentVector &attach
     }
     return result;
 }
+
+// static
+bool FragmentOutputState::GetDualSourceBlending(const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state) {
+    if (!color_blend_state) {
+        return false;
+    }
+    const std::array<VkBlendFactor, 4> dual_modes = {
+        VK_BLEND_FACTOR_SRC1_COLOR,
+        VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR,
+        VK_BLEND_FACTOR_SRC1_ALPHA,
+        VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA,
+    };
+    for (uint32_t i = 0; i < color_blend_state->attachmentCount; ++i) {
+        const auto &attachment = color_blend_state->pAttachments[i];
+        if (attachment.blendEnable) {
+            if (std::find(dual_modes.begin(), dual_modes.end(), attachment.srcColorBlendFactor) != dual_modes.end() ||
+                std::find(dual_modes.begin(), dual_modes.end(), attachment.dstColorBlendFactor) != dual_modes.end() ||
+                std::find(dual_modes.begin(), dual_modes.end(), attachment.srcAlphaBlendFactor) != dual_modes.end() ||
+                std::find(dual_modes.begin(), dual_modes.end(), attachment.dstAlphaBlendFactor) != dual_modes.end()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/layers/pipeline_sub_state.h
+++ b/layers/pipeline_sub_state.h
@@ -154,6 +154,7 @@ struct FragmentOutputState {
         if (create_info.pColorBlendState) {
             if (create_info.pColorBlendState) {
                 color_blend_state = ToSafeColorBlendState(*create_info.pColorBlendState);
+                dual_source_blending = GetDualSourceBlending(color_blend_state.get());
             }
             const auto &cbci = *create_info.pColorBlendState;
             if (cbci.attachmentCount) {
@@ -173,6 +174,7 @@ struct FragmentOutputState {
     }
 
     static bool IsBlendConstantsEnabled(const AttachmentVector &attachments);
+    static bool GetDualSourceBlending(const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state);
 
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     uint32_t subpass = 0;
@@ -184,4 +186,5 @@ struct FragmentOutputState {
 
     bool blend_constants_enabled = false;  // Blend constants enabled for any attachments
     bool sample_location_enabled = false;
+    bool dual_source_blending = false;
 };

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -310,6 +310,14 @@ layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const
     return result;
 }
 
+layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology() const {
+    if (static_data_.entry_points.size() > 0) {
+        const auto entrypoint = static_data_.entry_points.cbegin()->second;
+        return GetTopology(get_def(entrypoint.offset));
+    }
+    return {};
+}
+
 SHADER_MODULE_STATE::SpirvStaticData::SpirvStaticData(const SHADER_MODULE_STATE &module_state) {
     for (auto insn : module_state) {
         const uint32_t result_word = OpcodeResultWord(insn.opcode());

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -348,6 +348,10 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(spirv_inst_iter entrypoint) const;
     layer_data::optional<VkPrimitiveTopology> GetTopology(const spirv_inst_iter &entrypoint) const;
+    // TODO (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450)
+    // Since we currently don't support multiple entry points, this is a helper to return the topology
+    // for the "first" (and for our purposes _only_) entrypoint.
+    layer_data::optional<VkPrimitiveTopology> GetTopology() const;
 
     const EntryPoint *FindEntrypointStruct(char const *name, VkShaderStageFlagBits stageBits) const;
     spirv_inst_iter FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -121,7 +121,7 @@ static uint32_t GetShaderStageId(VkShaderStageFlagBits stage) {
     return bit_pos - 1;
 }
 
-bool CoreChecks::ValidateViConsistency(VkPipelineVertexInputStateCreateInfo const *vi) const {
+bool CoreChecks::ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const *vi) const {
     // Walk the binding descriptions, which describe the step rate and stride of each vertex buffer.  Each binding should
     // be specified only once.
     layer_data::unordered_map<uint32_t, VkVertexInputBindingDescription const *> bindings;
@@ -142,8 +142,8 @@ bool CoreChecks::ValidateViConsistency(VkPipelineVertexInputStateCreateInfo cons
     return skip;
 }
 
-bool CoreChecks::ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo const *vi, SHADER_MODULE_STATE const *module_state,
-                                           spirv_inst_iter entrypoint) const {
+bool CoreChecks::ValidateViAgainstVsInputs(safe_VkPipelineVertexInputStateCreateInfo const *vi,
+                                           SHADER_MODULE_STATE const *module_state, spirv_inst_iter entrypoint) const {
     bool skip = false;
 
     const auto inputs = module_state->CollectInterfaceByLocation(entrypoint, spv::StorageClassInput, false);
@@ -213,31 +213,32 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODUL
         location_map[location].output = &output_it.second;
     }
 
-    const bool alpha_to_coverage_enabled = pipeline->create_info.graphics.pMultisampleState != NULL &&
-        pipeline->create_info.graphics.pMultisampleState->alphaToCoverageEnable == VK_TRUE;
+    const auto ms_state = pipeline->MultisampleState();
+    const bool alpha_to_coverage_enabled = ms_state && (ms_state->alphaToCoverageEnable == VK_TRUE);
 
     for (uint32_t location = 0; location < location_map.size(); ++location) {
          const auto output = location_map[location].output;
 
-        if (!output && location < pipeline->attachments.size() && pipeline->attachments[location].colorWriteMask != 0) {
-            skip |= LogWarning(
-                module_state->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
-                "Attachment %" PRIu32 " not written by fragment shader; undefined values will be written to attachment", location);
-        } else if (output &&
-                  (location < pipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
-            auto format = pipeline->rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
-            const auto attachment_type = GetFormatType(format);
-            const auto output_type = module_state->GetFundamentalType(output->type_id);
+         const auto &rp_state = pipeline->RenderPassState();
+         const auto &attachments = pipeline->Attachments();
+         if (!output && location < attachments.size() && attachments[location].colorWriteMask != 0) {
+             skip |= LogWarning(
+                 module_state->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
+                 "Attachment %" PRIu32 " not written by fragment shader; undefined values will be written to attachment", location);
+         } else if (output && (location < rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
+             auto format = rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
+             const auto attachment_type = GetFormatType(format);
+             const auto output_type = module_state->GetFundamentalType(output->type_id);
 
-            // Type checking
-            if (!(output_type & attachment_type)) {
-                skip |=
-                    LogWarning(module_state->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
-                               "Attachment %" PRIu32
-                               " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
-                               location, string_VkFormat(format), module_state->DescribeType(output->type_id).c_str());
-            }
-        }
+             // Type checking
+             if (!(output_type & attachment_type)) {
+                 skip |=
+                     LogWarning(module_state->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
+                                "Attachment %" PRIu32
+                                " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
+                                location, string_VkFormat(format), module_state->DescribeType(output->type_id).c_str());
+             }
+         }
     }
 
     const auto output_zero = location_map.count(0) ? location_map[0].output : nullptr;
@@ -262,8 +263,9 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *m
     };
     std::map<uint32_t, Attachment> location_map;
 
-    if (pipeline->rp_state && !pipeline->rp_state->use_dynamic_rendering) {
-        const auto rpci = pipeline->rp_state->createInfo.ptr();
+    const auto &rp_state = pipeline->RenderPassState();
+    if (rp_state && !rp_state->use_dynamic_rendering) {
+        const auto rpci = rp_state->createInfo.ptr();
         const auto subpass = rpci->pSubpasses[subpass_index];
         for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
             auto const &reference = subpass.pColorAttachments[i];
@@ -283,11 +285,12 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *m
         location_map[location].output = &output_it.second;
     }
 
-    const bool alpha_to_coverage_enabled = pipeline->create_info.graphics.pMultisampleState != NULL &&
-                                           pipeline->create_info.graphics.pMultisampleState->alphaToCoverageEnable == VK_TRUE;
+    const auto *ms_state = pipeline->MultisampleState();
+    const bool alpha_to_coverage_enabled = ms_state && (ms_state->alphaToCoverageEnable == VK_TRUE);
 
     // Don't check any color attachments if rasterization is disabled
-    if (!pipeline->create_info.graphics.pRasterizationState->rasterizerDiscardEnable) {
+    const auto raster_state = pipeline->RasterizationState();
+    if (!raster_state->rasterizerDiscardEnable) {
         for (const auto &location_it : location_map) {
             const auto reference = location_it.second.reference;
             if (reference != nullptr && reference->attachment == VK_ATTACHMENT_UNUSED) {
@@ -298,7 +301,8 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *m
             const auto attachment = location_it.second.attachment;
             const auto output = location_it.second.output;
             if (attachment && !output) {
-                if (location < pipeline->attachments.size() && pipeline->attachments[location].colorWriteMask != 0) {
+                const auto &attachments = pipeline->Attachments();
+                if (location < attachments.size() && attachments[location].colorWriteMask != 0) {
                     skip |= LogWarning(module_state->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
                                        "Attachment %" PRIu32
                                        " not written by fragment shader; undefined values will be written to attachment",
@@ -377,7 +381,7 @@ PushConstantByteState CoreChecks::ValidatePushConstantSetUpdate(const std::vecto
 }
 
 bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, SHADER_MODULE_STATE const *module_state,
-                                           VkPipelineShaderStageCreateInfo const *pStage, const std::string &vuid) const {
+                                           safe_VkPipelineShaderStageCreateInfo const *pStage, const std::string &vuid) const {
     bool skip = false;
     // Temp workaround to prevent false positive errors
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450
@@ -390,7 +394,8 @@ bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, SHADE
     if (!entrypoint || !entrypoint->push_constant_used_in_shader.IsUsed()) {
         return skip;
     }
-    std::vector<VkPushConstantRange> const *push_constant_ranges = pipeline.pipeline_layout->push_constant_ranges.get();
+    const auto &pipeline_layout = pipeline.PipelineLayoutState();
+    std::vector<VkPushConstantRange> const *push_constant_ranges = pipeline_layout->push_constant_ranges.get();
 
     bool found_stage = false;
     for (auto const &range : *push_constant_ranges) {
@@ -409,10 +414,10 @@ bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, SHADE
             if (ret == PC_Byte_Not_Set) {
                 const auto loc_descr = entrypoint->push_constant_used_in_shader.GetLocationDesc(issue_index);
                 LogObjectList objlist(module_state->vk_shader_module());
-                objlist.add(pipeline.pipeline_layout->layout());
+                objlist.add(pipeline_layout->layout());
                 skip |= LogError(objlist, vuid, "Push constant buffer:%s in %s is out of range in %s.", loc_descr.c_str(),
                                  string_VkShaderStageFlags(pStage->stage).c_str(),
-                                 report_data->FormatHandle(pipeline.pipeline_layout->layout()).c_str());
+                                 report_data->FormatHandle(pipeline_layout->layout()).c_str());
                 break;
             }
         }
@@ -420,12 +425,11 @@ bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, SHADE
 
     if (!found_stage) {
         LogObjectList objlist(module_state->vk_shader_module());
-        objlist.add(pipeline.pipeline_layout->layout());
-        skip |= LogError(objlist, vuid, "Push constant is used in %s of %s. But %s doesn't set %s.",
-                         string_VkShaderStageFlags(pStage->stage).c_str(),
-                         report_data->FormatHandle(module_state->vk_shader_module()).c_str(),
-                         report_data->FormatHandle(pipeline.pipeline_layout->layout()).c_str(),
-                         string_VkShaderStageFlags(pStage->stage).c_str());
+        objlist.add(pipeline_layout->layout());
+        skip |= LogError(
+            objlist, vuid, "Push constant is used in %s of %s. But %s doesn't set %s.",
+            string_VkShaderStageFlags(pStage->stage).c_str(), report_data->FormatHandle(module_state->vk_shader_module()).c_str(),
+            report_data->FormatHandle(pipeline_layout->layout()).c_str(), string_VkShaderStageFlags(pStage->stage).c_str());
     }
     return skip;
 }
@@ -469,10 +473,10 @@ bool CoreChecks::ValidateBuiltinLimits(SHADER_MODULE_STATE const *module_state, 
 }
 
 // Validate that data for each specialization entry is fully contained within the buffer.
-bool CoreChecks::ValidateSpecializations(VkPipelineShaderStageCreateInfo const *info) const {
+bool CoreChecks::ValidateSpecializations(safe_VkPipelineShaderStageCreateInfo const *info) const {
     bool skip = false;
 
-    VkSpecializationInfo const *spec = info->pSpecializationInfo;
+    const auto *spec = info->pSpecializationInfo;
 
     if (spec) {
         for (auto i = 0u; i < spec->mapEntryCount; i++) {
@@ -753,8 +757,8 @@ bool CoreChecks::ValidateMemoryScope(SHADER_MODULE_STATE const *module_state, co
 }
 
 bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const *module_state,
-                                                      VkPipelineShaderStageCreateInfo const *pStage, const PIPELINE_STATE *pipeline,
-                                                      spirv_inst_iter entrypoint) const {
+                                                      safe_VkPipelineShaderStageCreateInfo const *pStage,
+                                                      const PIPELINE_STATE *pipeline, spirv_inst_iter entrypoint) const {
     if (pStage->stage == VK_SHADER_STAGE_COMPUTE_BIT || pStage->stage == VK_SHADER_STAGE_ALL_GRAPHICS ||
         pStage->stage == VK_SHADER_STAGE_ALL) {
         return false;
@@ -1154,43 +1158,46 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
         return false;
     }
 
-    if (stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
-        if (pipeline->rp_state->use_dynamic_rendering) {
-            total_resources += pipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount;
+    const auto &rp_state = pipeline->RenderPassState();
+    if ((stage == VK_SHADER_STAGE_FRAGMENT_BIT) && rp_state) {
+        if (rp_state->use_dynamic_rendering) {
+            total_resources += rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount;
         } else {
             // "For the fragment shader stage the framebuffer color attachments also count against this limit"
-            total_resources +=
-                pipeline->rp_state->createInfo.pSubpasses[pipeline->create_info.graphics.subpass].colorAttachmentCount;
+            total_resources += rp_state->createInfo.pSubpasses[pipeline->Subpass()].colorAttachmentCount;
         }
     }
 
     // TODO: This reuses a lot of GetDescriptorCountMaxPerStage but currently would need to make it agnostic in a way to handle
     // input from CreatePipeline and CreatePipelineLayout level
-    for (auto set_layout : pipeline->pipeline_layout->set_layouts) {
-        if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) != 0) {
-            continue;
-        }
+    const auto &layout_state = pipeline->PipelineLayoutState();
+    if (layout_state) {
+        for (auto set_layout : layout_state->set_layouts) {
+            if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) != 0) {
+                continue;
+            }
 
-        for (uint32_t binding_idx = 0; binding_idx < set_layout->GetBindingCount(); binding_idx++) {
-            const VkDescriptorSetLayoutBinding *binding = set_layout->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
-            // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
-            if (((stage & binding->stageFlags) != 0) && (binding->descriptorCount > 0)) {
-                // Check only descriptor types listed in maxPerStageResources description in spec
-                switch (binding->descriptorType) {
-                    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-                    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-                        total_resources += binding->descriptorCount;
-                        break;
-                    default:
-                        break;
+            for (uint32_t binding_idx = 0; binding_idx < set_layout->GetBindingCount(); binding_idx++) {
+                const VkDescriptorSetLayoutBinding *binding = set_layout->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+                // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
+                if (((stage & binding->stageFlags) != 0) && (binding->descriptorCount > 0)) {
+                    // Check only descriptor types listed in maxPerStageResources description in spec
+                    switch (binding->descriptorType) {
+                        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+                        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+                        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                            total_resources += binding->descriptorCount;
+                            break;
+                        default:
+                            break;
+                    }
                 }
             }
         }
@@ -1209,8 +1216,9 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
 }
 
 // copy the specialization constant value into buf, if it is present
-void GetSpecConstantValue(VkPipelineShaderStageCreateInfo const *pStage, uint32_t spec_id, void *buf) {
-    VkSpecializationInfo const *spec = pStage->pSpecializationInfo;
+template <typename StageCreateInfo>
+void GetSpecConstantValue(StageCreateInfo const *pStage, uint32_t spec_id, void *buf) {
+    const auto *spec = pStage->pSpecializationInfo;
 
     if (spec && spec_id < spec->mapEntryCount) {
         memcpy(buf, (uint8_t *)spec->pData + spec->pMapEntries[spec_id].offset, spec->pMapEntries[spec_id].size);
@@ -1220,7 +1228,7 @@ void GetSpecConstantValue(VkPipelineShaderStageCreateInfo const *pStage, uint32_
 // Fill in value with the constant or specialization constant value, if available.
 // Returns true if the value has been accurately filled out.
 static bool GetIntConstantValue(spirv_inst_iter insn, SHADER_MODULE_STATE const *module_state,
-                                VkPipelineShaderStageCreateInfo const *pStage,
+                                safe_VkPipelineShaderStageCreateInfo const *pStage,
                                 const layer_data::unordered_map<uint32_t, uint32_t> &id_to_spec_id, uint32_t *value) {
     auto type_id = module_state->get_def(insn.word(1));
     if (type_id.opcode() != spv::OpTypeInt || type_id.word(2) != 32) {
@@ -1273,7 +1281,8 @@ VkComponentTypeNV GetComponentType(spirv_inst_iter insn, SHADER_MODULE_STATE con
 
 // Validate SPV_NV_cooperative_matrix behavior that can't be statically validated
 // in SPIRV-Tools (e.g. due to specialization constant usage).
-bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_state, VkPipelineShaderStageCreateInfo const *pStage,
+bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_state,
+                                           safe_VkPipelineShaderStageCreateInfo const *pStage,
                                            const PIPELINE_STATE *pipeline) const {
     bool skip = false;
 
@@ -1289,7 +1298,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_sta
 
         CoopMatType() : scope(0), rows(0), cols(0), component_type(VK_COMPONENT_TYPE_MAX_ENUM_NV), all_constant(false) {}
 
-        void Init(uint32_t id, SHADER_MODULE_STATE const *module_state, VkPipelineShaderStageCreateInfo const *pStage,
+        void Init(uint32_t id, SHADER_MODULE_STATE const *module_state, safe_VkPipelineShaderStageCreateInfo const *pStage,
                   const layer_data::unordered_map<uint32_t, uint32_t> &id_to_spec_id) {
             spirv_inst_iter insn = module_state->get_def(id);
             uint32_t component_type_id = insn.word(2);
@@ -1475,7 +1484,8 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_sta
     return skip;
 }
 
-bool CoreChecks::ValidateShaderResolveQCOM(SHADER_MODULE_STATE const *module_state, VkPipelineShaderStageCreateInfo const *pStage,
+bool CoreChecks::ValidateShaderResolveQCOM(SHADER_MODULE_STATE const *module_state,
+                                           safe_VkPipelineShaderStageCreateInfo const *pStage,
                                            const PIPELINE_STATE *pipeline) const {
     bool skip = false;
 
@@ -1486,10 +1496,8 @@ bool CoreChecks::ValidateShaderResolveQCOM(SHADER_MODULE_STATE const *module_sta
             switch (insn.opcode()) {
                 case spv::OpCapability:
                     if (insn.word(1) == spv::CapabilitySampleRateShading) {
-                        auto subpass_flags =
-                            (pipeline->rp_state == nullptr)
-                                ? 0
-                                : pipeline->rp_state->createInfo.pSubpasses[pipeline->create_info.graphics.subpass].flags;
+                        const auto &rp_state = pipeline->RenderPassState();
+                        auto subpass_flags = (!rp_state) ? 0 : rp_state->createInfo.pSubpasses[pipeline->Subpass()].flags;
                         if ((subpass_flags & VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM) != 0) {
                             skip |=
                                 LogError(pipeline->pipeline(), "VUID-RuntimeSpirv-SampleRateShading-06378",
@@ -1507,7 +1515,7 @@ bool CoreChecks::ValidateShaderResolveQCOM(SHADER_MODULE_STATE const *module_sta
     return skip;
 }
 
-bool CoreChecks::ValidateShaderSubgroupSizeControl(VkPipelineShaderStageCreateInfo const *pStage) const {
+bool CoreChecks::ValidateShaderSubgroupSizeControl(safe_VkPipelineShaderStageCreateInfo const *pStage) const {
     bool skip = false;
 
     if ((pStage->flags & VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) != 0 &&
@@ -2077,17 +2085,17 @@ bool CoreChecks::ValidateExecutionModes(SHADER_MODULE_STATE const *module_state,
                 }
 
                 case spv::ExecutionModeEarlyFragmentTests: {
+                    const auto *ds_state = (pipeline) ? pipeline->DepthStencilState() : nullptr;
                     if ((stage == VK_SHADER_STAGE_FRAGMENT_BIT) &&
-                        (pipeline && pipeline->create_info.graphics.pDepthStencilState &&
-                         (pipeline->create_info.graphics.pDepthStencilState->flags &
+                        (ds_state &&
+                         (ds_state->flags &
                           (VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_ARM |
                            VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM)) != 0)) {
                         skip |= LogError(
                             device, " VUID-VkGraphicsPipelineCreateInfo-pStages-06466",
                             "The fragment shader enables early fragment tests, but VkPipelineDepthStencilStateCreateInfo::flags == "
                             "%s",
-                            string_VkPipelineDepthStencilStateCreateFlags(pipeline->create_info.graphics.pDepthStencilState->flags)
-                                .c_str());
+                            string_VkPipelineDepthStencilStateCreateFlags(ds_state->flags).c_str());
                     }
                     break;
                 }
@@ -2193,10 +2201,11 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const PIPELINE_STATE *pipeline
         }
     }
 
+    const auto viewport_state = pipeline->ViewportState();
     if (!phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports &&
-        (pipeline->GetPipelineType() == VK_PIPELINE_BIND_POINT_GRAPHICS) && pipeline->create_info.graphics.pViewportState) {
-        if (!IsDynamic(pipeline, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT) &&
-            pipeline->create_info.graphics.pViewportState->viewportCount > 1 && primitiverate_written) {
+        (pipeline->GetPipelineType() == VK_PIPELINE_BIND_POINT_GRAPHICS) && viewport_state) {
+        if (!IsDynamic(pipeline, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT) && viewport_state->viewportCount > 1 &&
+            primitiverate_written) {
             skip |= LogError(pipeline->pipeline(),
                              "VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04503",
                              "vkCreateGraphicsPipelines: %s shader statically writes to PrimitiveShadingRateKHR built-in, but "
@@ -2767,7 +2776,8 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     skip |= ValidateExecutionModes(module_state, entrypoint, pStage->stage, pipeline);
     skip |= ValidateSpecializations(pStage);
     skip |= ValidateDecorations(module_state);
-    if (check_point_size && !pipeline->create_info.graphics.pRasterizationState->rasterizerDiscardEnable) {
+    const auto *raster_state = pipeline->RasterizationState();
+    if (check_point_size && !raster_state->rasterizerDiscardEnable) {
         skip |= ValidatePointListShaderState(pipeline, module_state, entrypoint, pStage->stage);
     }
     skip |= ValidateBuiltinLimits(module_state, entrypoint);
@@ -2787,7 +2797,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     // "layout must be consistent with the layout of the * shader"
     // 'consistent' -> #descriptorsets-pipelinelayout-consistency
     std::string vuid_layout_mismatch;
-    switch (pipeline->create_info.graphics.sType) {
+    switch (pipeline->GetUnifiedCreateInfo().graphics.sType) {
         case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
             vuid_layout_mismatch = "VUID-VkGraphicsPipelineCreateInfo-layout-00756";
             break;
@@ -2811,8 +2821,10 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     // Validate descriptor use
     for (auto use : stage_state.descriptor_uses) {
         // Verify given pipelineLayout has requested setLayout with requested binding
-        const auto &binding = GetDescriptorBinding(pipeline->pipeline_layout.get(), use.first);
-        uint32_t required_descriptor_count;
+        // const auto& layout_state = (stage_state.stage_flag == VK_SHADER_STAGE_VERTEX_BIT) ?
+        // pipeline->PreRasterPipelineLayoutState() : pipeline->FragmentShaderPipelineLayoutState();
+        const auto &binding = GetDescriptorBinding(pipeline->PipelineLayoutState().get(), use.first);
+        unsigned required_descriptor_count;
         bool is_khr = binding && binding->descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
         std::set<uint32_t> descriptor_types =
             TypeToDescriptorTypeSet(module_state, use.second.type_id, required_descriptor_count, is_khr);
@@ -2842,9 +2854,10 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     if (pStage->stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
         auto input_attachment_uses = module_state->CollectInterfaceByInputAttachmentIndex(accessible_ids);
 
-        if (!pipeline->rp_state->use_dynamic_rendering) {
-            auto rpci = pipeline->rp_state->createInfo.ptr();
-            auto subpass = pipeline->create_info.graphics.subpass;
+        const auto &rp_state = pipeline->RenderPassState();
+        if (rp_state && !rp_state->use_dynamic_rendering) {
+            auto rpci = rp_state->createInfo.ptr();
+            auto subpass = pipeline->Subpass();
             for (auto use : input_attachment_uses) {
                 auto input_attachments = rpci->pSubpasses[subpass].pInputAttachments;
                 auto index = (input_attachments && use.first < rpci->pSubpasses[subpass].inputAttachmentCount)
@@ -3004,12 +3017,9 @@ bool CoreChecks::ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const *produ
     return skip;
 }
 
-static inline uint32_t DetermineFinalGeomStage(const PIPELINE_STATE *pipeline, const VkGraphicsPipelineCreateInfo *pCreateInfo) {
-    uint32_t stage_mask = 0;
-    if (pipeline->topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_POINT_LIST) {
-        for (uint32_t i = 0; i < pCreateInfo->stageCount; i++) {
-            stage_mask |= pCreateInfo->pStages[i].stage;
-        }
+static inline uint32_t DetermineFinalGeomStage(const PIPELINE_STATE &pipeline) {
+    uint32_t stage_mask = pipeline.active_shaders;
+    if (pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_POINT_LIST) {
         // Determine which shader in which PointSize should be written (the final geometry stage)
         if (stage_mask & VK_SHADER_STAGE_MESH_BIT_NV) {
             stage_mask = VK_SHADER_STAGE_MESH_BIT_NV;
@@ -3027,11 +3037,16 @@ static inline uint32_t DetermineFinalGeomStage(const PIPELINE_STATE *pipeline, c
 // Validate that the shaders used by the given pipeline and store the active_slots
 //  that are actually used by the pipeline into pPipeline->active_slots
 bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipeline) const {
-    const auto create_info = pipeline->create_info.graphics.ptr();
-
     bool skip = false;
 
-    uint32_t pointlist_stage_mask = DetermineFinalGeomStage(pipeline, create_info);
+    if (pipeline->IsGraphicsLibrary()) {
+        // Only validate stages in an executable pipeline, not a graphics library
+        // TODO This currently makes executing executable pipeline more expensive than they need to be since we could be validating
+        // more per library.
+        return skip;
+    }
+
+    uint32_t pointlist_stage_mask = DetermineFinalGeomStage(*pipeline);
 
     const PipelineStageState *vertex_stage = nullptr, *fragment_stage = nullptr;
     for (auto &stage : pipeline->stage_state) {
@@ -3047,14 +3062,14 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
     // if the shader stages are no good individually, cross-stage validation is pointless.
     if (skip) return true;
 
-    auto vi = create_info->pVertexInputState;
+    auto vi_state = pipeline->InputState();
 
-    if (vi) {
-        skip |= ValidateViConsistency(vi);
+    if (vi_state) {
+        skip |= ValidateViConsistency(vi_state);
     }
 
     if (vertex_stage && vertex_stage->module_state->has_valid_spirv && !IsDynamic(pipeline, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
-        skip |= ValidateViAgainstVsInputs(vi, vertex_stage->module_state.get(), vertex_stage->entrypoint);
+        skip |= ValidateViAgainstVsInputs(vi_state, vertex_stage->module_state.get(), vertex_stage->entrypoint);
     }
 
     for (size_t i = 1; i < pipeline->stage_state.size(); i++) {
@@ -3076,12 +3091,13 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
     }
 
     if (fragment_stage && fragment_stage->module_state->has_valid_spirv) {
-        if (pipeline->rp_state->use_dynamic_rendering) {
+        const auto &rp_state = pipeline->RenderPassState();
+        if (rp_state && rp_state->use_dynamic_rendering) {
             skip |= ValidateFsOutputsAgainstDynamicRenderingRenderPass(fragment_stage->module_state.get(),
                                                                        fragment_stage->entrypoint, pipeline);
         } else {
             skip |= ValidateFsOutputsAgainstRenderPass(fragment_stage->module_state.get(), fragment_stage->entrypoint, pipeline,
-                                                       create_info->subpass);
+                                                       pipeline->Subpass());
         }
     }
 
@@ -3118,7 +3134,7 @@ bool CoreChecks::ValidateComputePipelineShaderState(PIPELINE_STATE *pipeline) co
 
 uint32_t CoreChecks::CalcShaderStageCount(const PIPELINE_STATE *pipeline, VkShaderStageFlagBits stageBit) const {
     uint32_t total = 0;
-    const auto &create_info = pipeline->create_info.raytracing;
+    const auto &create_info = pipeline->GetUnifiedCreateInfo().raytracing;
     const auto *stages = create_info.ptr()->pStages;
     for (uint32_t stage_index = 0; stage_index < create_info.stageCount; stage_index++) {
         if (stages[stage_index].stage == stageBit) {
@@ -3141,7 +3157,7 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE *pipeline, uint32_t gro
         return true;
     }
 
-    const auto &create_info = pipeline->create_info.raytracing;
+    const auto &create_info = pipeline->GetUnifiedCreateInfo().raytracing;
     const auto *stages = create_info.ptr()->pStages;
 
     if (group < create_info.stageCount) {
@@ -3153,9 +3169,9 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE *pipeline, uint32_t gro
     if (create_info.pLibraryInfo) {
         for (uint32_t i = 0; i < create_info.pLibraryInfo->libraryCount; ++i) {
             auto library_pipeline = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[i]);
-            const uint32_t stage_count = library_pipeline->create_info.raytracing.ptr()->stageCount;
+            const uint32_t stage_count = library_pipeline->GetUnifiedCreateInfo().raytracing.ptr()->stageCount;
             if (group < stage_count) {
-                return (library_pipeline->create_info.raytracing.ptr()->pStages[group].stage & stage) != 0;
+                return (library_pipeline->GetUnifiedCreateInfo().raytracing.ptr()->pStages[group].stage & stage) != 0;
             }
             group -= stage_count;
         }
@@ -3168,7 +3184,7 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE *pipeline, uint32_t gro
 bool CoreChecks::ValidateRayTracingPipeline(PIPELINE_STATE *pipeline, VkPipelineCreateFlags flags, bool isKHR) const {
     bool skip = false;
 
-    const auto &create_info = pipeline->create_info.raytracing;
+    const auto &create_info = pipeline->GetUnifiedCreateInfo().raytracing;
     if (isKHR) {
         if (create_info.maxPipelineRayRecursionDepth > phys_dev_ext_props.ray_tracing_propsKHR.maxRayRecursionDepth) {
             skip |=
@@ -3179,8 +3195,8 @@ bool CoreChecks::ValidateRayTracingPipeline(PIPELINE_STATE *pipeline, VkPipeline
         }
         if (create_info.pLibraryInfo) {
             for (uint32_t i = 0; i < create_info.pLibraryInfo->libraryCount; ++i) {
-                auto library_pipelinestate = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[i]);
-                const auto &library_create_info = library_pipelinestate->create_info.raytracing;
+                const auto library_pipelinestate = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[i]);
+                const auto &library_create_info = library_pipelinestate->GetUnifiedCreateInfo().raytracing;
                 if (library_create_info.maxPipelineRayRecursionDepth != create_info.maxPipelineRayRecursionDepth) {
                     skip |= LogError(
                         device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraries-03591",

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2367,10 +2367,9 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
 
     auto pipe_state = Get<PIPELINE_STATE>(pipeline);
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == pipelineBindPoint) {
-        const auto &create_info = pipe_state->create_info.graphics;
-        bool rasterization_enabled = VK_FALSE == create_info.pRasterizationState->rasterizerDiscardEnable;
-        const auto *viewport_state = create_info.pViewportState;
-        const auto *dynamic_state = create_info.pDynamicState;
+        bool rasterization_enabled = VK_FALSE == pipe_state->RasterizationState()->rasterizerDiscardEnable;
+        const auto *viewport_state = pipe_state->ViewportState();
+        const auto *dynamic_state = pipe_state->DynamicState();
         cb_state->status &= ~cb_state->static_status;
         cb_state->static_status = MakeStaticStateMask(dynamic_state ? dynamic_state->ptr() : nullptr);
         cb_state->status |= cb_state->static_status;
@@ -4661,10 +4660,10 @@ void ValidationStateTracker::PreCallRecordCmdSetVertexInputEXT(
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
     if (pipeline_state) {
-        if (pipeline_state->create_info.graphics.pDynamicState) {
-            for (uint32_t i = 0; i < pipeline_state->create_info.graphics.pDynamicState->dynamicStateCount; ++i) {
-                if (pipeline_state->create_info.graphics.pDynamicState->pDynamicStates[i] ==
-                    VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT) {
+        const auto *dynamic_state = pipeline_state->DynamicState();
+        if (dynamic_state) {
+            for (uint32_t i = 0; i < dynamic_state->dynamicStateCount; ++i) {
+                if (dynamic_state->pDynamicStates[i] == VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT) {
                     status_flags |= CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET;
                     break;
                 }


### PR DESCRIPTION
Make a number of fields in PIPELINE_STATE private. This is done to
enforce outside code to use accessors, which is a necessary precursor to
breaking up pipeline state into sub-states.